### PR TITLE
feat: show DanXi Care dialog when attempting to send posts with care words

### DIFF
--- a/lib/page/opentreehole/hole_editor.dart
+++ b/lib/page/opentreehole/hole_editor.dart
@@ -28,11 +28,13 @@ import 'package:dan_xi/provider/fduhole_provider.dart';
 import 'package:dan_xi/provider/settings_provider.dart';
 import 'package:dan_xi/repository/opentreehole/opentreehole_repository.dart';
 import 'package:dan_xi/util/browser_util.dart';
+import 'package:dan_xi/util/danxi_care.dart';
 import 'package:dan_xi/util/master_detail_view.dart';
 import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/opentreehole/editor_object.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
+import 'package:dan_xi/widget/dialogs/care_dialog.dart';
 import 'package:dan_xi/widget/libraries/error_page_widget.dart';
 import 'package:dan_xi/widget/libraries/image_picker_proxy.dart';
 import 'package:dan_xi/widget/libraries/linkify_x.dart';
@@ -605,6 +607,7 @@ class BBSEditorPageState extends State<BBSEditorPage> {
 
   bool _isFullscreen = false;
   bool? _supportTags;
+  bool _confirmCareWords = false;
 
   String? _tip;
   late EditorObject _object;
@@ -680,7 +683,23 @@ class BBSEditorPageState extends State<BBSEditorPage> {
               icon: PlatformX.isMaterial(context)
                   ? const Icon(Icons.send)
                   : const Icon(CupertinoIcons.paperplane),
-              onPressed: _canSend ? () => _sendDocument(_object) : null),
+              onPressed: _canSend
+                  ? () async {
+                      bool isCareWordsDetected =
+                          await detectCareWords(_controller.text);
+                      WidgetsBinding.instance.addPostFrameCallback((_) async {
+                        if (isCareWordsDetected && _confirmCareWords == false) {
+                          await showPlatformDialog(
+                              context: context,
+                              builder: (_) => const CareDialog());
+                          _confirmCareWords = true;
+                          return;
+                        }
+                        _sendDocument(_object);
+                      });
+                    }
+                  : null,
+          ),
         ],
       ),
       body: SafeArea(

--- a/lib/page/opentreehole/hole_editor.dart
+++ b/lib/page/opentreehole/hole_editor.dart
@@ -687,18 +687,16 @@ class BBSEditorPageState extends State<BBSEditorPage> {
                   ? () async {
                       bool isCareWordsDetected =
                           await detectCareWords(_controller.text);
-                      WidgetsBinding.instance.addPostFrameCallback((_) async {
-                        // only show once
-                        if (isCareWordsDetected == true &&
-                            _confirmCareWords == false) {
-                          await showPlatformDialog(
-                              context: context,
-                              builder: (_) => const CareDialog());
-                          _confirmCareWords = true;
-                          return;
-                        }
-                        _sendDocument(_object);
-                      });
+                      // only show once
+                      if (context.mounted == true &&
+                          isCareWordsDetected == true &&
+                          _confirmCareWords == false) {
+                        await showPlatformDialog(
+                            context: context, builder: (_) => const CareDialog());
+                        _confirmCareWords = true;
+                        return;
+                      }
+                      _sendDocument(_object);
                     }
                   : null,
           ),

--- a/lib/page/opentreehole/hole_editor.dart
+++ b/lib/page/opentreehole/hole_editor.dart
@@ -688,7 +688,9 @@ class BBSEditorPageState extends State<BBSEditorPage> {
                       bool isCareWordsDetected =
                           await detectCareWords(_controller.text);
                       WidgetsBinding.instance.addPostFrameCallback((_) async {
-                        if (isCareWordsDetected && _confirmCareWords == false) {
+                        // only show once
+                        if (isCareWordsDetected == true &&
+                            _confirmCareWords == false) {
                           await showPlatformDialog(
                               context: context,
                               builder: (_) => const CareDialog());

--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -173,14 +173,12 @@ Widget searchByText(BuildContext context, String searchKeyword) {
           onTap: () async {
             submit(context, searchKeyword);
             bool isCareWordsDetected = await detectCareWords(searchKeyword);
-            WidgetsBinding.instance.addPostFrameCallback((_) async {
-              if (isCareWordsDetected) {
-                await showPlatformDialog(
-                    context: context, builder: (_) => const CareDialog());
-              }
+            if (context.mounted && isCareWordsDetected) {
+              await showPlatformDialog(
+                  context: context, builder: (_) => const CareDialog());
+            }
               smartNavigatorPush(_globalKey.currentContext!, "/bbs/postDetail",
                   arguments: {"searchKeyword": searchKeyword});
-            });
           },
         );
       });


### PR DESCRIPTION
Issue #235 
The first time a user attempts to send posts with care words, DanXi Care dialog box will pop up, and the message will not be sent.
Only when clicking again will the post be actually sent.

PS. What's the necessity to use `WidgetsBinding.instance.addPostFrameCallback` here and in commit 52f547f ?

[[lib/page/opentreehole/hole_search.dart](https://github.com/DanXi-Dev/DanXi/blob/52f547fe74e7aab2e2825e600c7a7c042f705186/lib/page/opentreehole/hole_search.dart#L176)](https://github.com/DanXi-Dev/DanXi/blob/52f547fe74e7aab2e2825e600c7a7c042f705186/lib/page/opentreehole/hole_search.dart#L176-L183)