### PR TITLE
fix overflow in SearchHistory

### DIFF
--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -180,8 +180,8 @@ Widget searchByText(BuildContext context, String searchKeyword) {
               await showPlatformDialog(
                   context: context, builder: (_) => const CareDialog());
             }
-              smartNavigatorPush(_globalKey.currentContext!, "/bbs/postDetail",
-                  arguments: {"searchKeyword": searchKeyword});
+            smartNavigatorPush(_globalKey.currentContext!, "/bbs/postDetail",
+                arguments: {"searchKeyword": searchKeyword});
           },
         );
       });

--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -58,7 +58,10 @@ class _OTSearchPageState extends State<OTSearchPage> {
   /// The text user inputs.
   final TextEditingController _searchFieldController = TextEditingController();
 
-  Widget _buildSearchHistory(BuildContext context) => Column(
+  /// Use Expanded to avoid the uncertainty of column size,
+  /// thus solving Flexible overflow
+  Widget _buildSearchHistory(BuildContext context) => Expanded(
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Padding(
@@ -99,7 +102,7 @@ class _OTSearchPageState extends State<OTSearchPage> {
                     )),
           ),
         ],
-      );
+      ));
 
   /// Build a list of search suggestion or search history if no input.
   Widget buildSearchSuggestion(BuildContext context) =>

--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -58,10 +58,7 @@ class _OTSearchPageState extends State<OTSearchPage> {
   /// The text user inputs.
   final TextEditingController _searchFieldController = TextEditingController();
 
-  /// Use Expanded to avoid the uncertainty of column size,
-  /// thus solving Flexible overflow
-  Widget _buildSearchHistory(BuildContext context) => Expanded(
-      child: Column(
+  Widget _buildSearchHistory(BuildContext context) => Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Padding(
@@ -102,7 +99,7 @@ class _OTSearchPageState extends State<OTSearchPage> {
                     )),
           ),
         ],
-      ));
+      );
 
   /// Build a list of search suggestion or search history if no input.
   Widget buildSearchSuggestion(BuildContext context) =>

--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -104,19 +104,18 @@ class _OTSearchPageState extends State<OTSearchPage> {
   /// Build a list of search suggestion or search history if no input.
   Widget buildSearchSuggestion(BuildContext context) =>
       Consumer<TextEditingValue>(
-          builder: (context, value, child) => value.text.isEmpty
-              ? _buildSearchHistory(context)
-              : Expanded(
-                  child: ListView(
-                    primary: false,
-                    shrinkWrap: true,
-                    keyboardDismissBehavior:
-                        ScrollViewKeyboardDismissBehavior.onDrag,
-                    children: suggestionProviders
-                        .map((e) => e.call(context, value.text))
-                        .toList(),
-                  ),
-                ));
+        builder: (context, value, child) => value.text.isEmpty
+            ? _buildSearchHistory(context)
+            : ListView(
+                primary: false,
+                shrinkWrap: true,
+                keyboardDismissBehavior:
+                    ScrollViewKeyboardDismissBehavior.onDrag,
+                children: suggestionProviders
+                    .map((e) => e.call(context, value.text))
+                    .toList(),
+              ),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -147,7 +146,7 @@ class _OTSearchPageState extends State<OTSearchPage> {
             ),
             ValueListenableProvider.value(
                 value: _searchFieldController,
-                child: buildSearchSuggestion(context)),
+                child: Expanded(child: buildSearchSuggestion(context))),
           ],
         ),
       ),


### PR DESCRIPTION
The column of search history widget is nested in the main column, leaving the size of search history column uncertain.
This causes overflow when wrapping `ListView` in `Flexible`, or exception when wrapping it in `Expanded`.

After enclosing `Column` in `Expanded`, both `Flexible` and `Expanded` works well with `ListView`.
Closes #277