### PR TITLE
在任意平台上允许使用鼠标滚动页面

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,7 +127,7 @@ class TouchMouseScrollBehavior extends MaterialScrollBehavior {
   @override
   Set<PointerDeviceKind> get dragDevices => {
         PointerDeviceKind.touch,
-        if (PlatformX.isWindows) PointerDeviceKind.mouse,
+        PointerDeviceKind.mouse,
         PointerDeviceKind.stylus,
         PointerDeviceKind.invertedStylus,
         PointerDeviceKind.trackpad,


### PR DESCRIPTION
Fixes #287.

这将在所有环境（包括 iOS 和 Android）生效。

---

一些问题：

> 为什么要用鼠标？

1. Flutter 鼠标滚轮和触摸板都**不支持惯性滚动，只有触摸滑动支持**。我这个笔记本上，**手指从触摸板的最上端滑到最下端，旦夕页面才滚动不到一页的距离；鼠标滚轮滚动半圈，旦夕页面才滚动不到小半页的距离**，体验很差；
2. 有些控件只支持拖动浏览，例如 Banner。

> 不是有滚动条吗？

可以试试 Material 的滚动条，基本是个摆设：不仅视觉宽度过窄几乎察觉不到，而且实际触发区域也窄得吓人（用牙签才能戳到的细），无论是鼠标还是触摸，使用体验都很差。

> 说得好，那难道不应该去优化桌面端点击体验吗？

就目前的其他工作量来看，这不在规划上。允许鼠标拖动是目前的权宜之计，这至少能让用户正常浏览。

> 为什么是「所有环境」？在桌面上生效不就行了？

问题的重点在于 iOS 和 Android，而且是外接了鼠标的 iOS 和 Android。事实上，因为 iOS 和 Android 通常不外接鼠标，这里的更改对其无作用。相反，如果有人真的外接鼠标，启用这一功能是方便的（你会愿意在外接鼠标的 iPad 上，时不时把双手从键盘和鼠标上离开，去滑动屏幕吗？）。