### PR TITLE
Fix #226 and upgrade dependencies

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:bitsdojo_window_v3/bitsdojo_window_v3.dart';
 import 'package:dan_xi/feature/feature_map.dart';
 import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/page/danke/course_group_detail.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -196,7 +196,7 @@ class DanxiApp extends StatelessWidget {
         CourseReviewEditorPage(arguments: arguments)
   };
 
-  const DanxiApp({Key? key}) : super(key: key);
+  const DanxiApp({super.key});
 
   Widget errorBuilder(FlutterErrorDetails details) => Builder(
       builder: (context) =>

--- a/lib/page/danke/course_group_detail.dart
+++ b/lib/page/danke/course_group_detail.dart
@@ -29,6 +29,7 @@ import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/opentreehole/paged_listview_helper.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
+import 'package:dan_xi/util/stream_listener.dart';
 import 'package:dan_xi/widget/danke/course_review_widget.dart';
 import 'package:dan_xi/widget/danke/course_widgets.dart';
 import 'package:dan_xi/widget/libraries/error_page_widget.dart';
@@ -42,7 +43,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
-import 'package:dan_xi/util/stream_listener.dart';
 
 enum FilterType { TEACHER_FILTER, TIME_FILTER }
 
@@ -57,7 +57,7 @@ class RefreshFilterEvent {
 class CourseGroupDetail extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const CourseGroupDetail({Key? key, this.arguments}) : super(key: key);
+  const CourseGroupDetail({super.key, this.arguments});
 
   @override
   CourseGroupDetailState createState() => CourseGroupDetailState();

--- a/lib/page/danke/course_review_editor.dart
+++ b/lib/page/danke/course_review_editor.dart
@@ -231,12 +231,11 @@ class CourseReviewEditorWidget extends StatefulWidget {
   final CourseReviewEditorText review;
 
   const CourseReviewEditorWidget(
-      {Key? key,
+      {super.key,
       this.fullscreen = false,
       required this.courseGroup,
       required this.review,
-      this.focusContent = false})
-      : super(key: key);
+      this.focusContent = false});
 
   final CourseGroup courseGroup;
 
@@ -617,7 +616,7 @@ class CourseRatingWidgetState extends State<CourseRatingWidget> {
 class CourseReviewEditorPage extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const CourseReviewEditorPage({Key? key, this.arguments}) : super(key: key);
+  const CourseReviewEditorPage({super.key, this.arguments});
 
   @override
   CourseReviewEditorPageState createState() => CourseReviewEditorPageState();

--- a/lib/page/dashboard/aao_notices.dart
+++ b/lib/page/dashboard/aao_notices.dart
@@ -37,7 +37,7 @@ class AAONoticesList extends StatefulWidget {
   @override
   AAONoticesListState createState() => AAONoticesListState();
 
-  const AAONoticesList({Key? key, this.arguments}) : super(key: key);
+  const AAONoticesList({super.key, this.arguments});
 }
 
 class AAONoticesListState extends State<AAONoticesList> {

--- a/lib/page/dashboard/announcement_notices.dart
+++ b/lib/page/dashboard/announcement_notices.dart
@@ -39,7 +39,7 @@ class AnnouncementList extends StatefulWidget {
   @override
   AnnouncementListState createState() => AnnouncementListState();
 
-  const AnnouncementList({Key? key, this.arguments}) : super(key: key);
+  const AnnouncementList({super.key, this.arguments});
 }
 
 class AnnouncementListState extends State<AnnouncementList> {

--- a/lib/page/dashboard/bus.dart
+++ b/lib/page/dashboard/bus.dart
@@ -41,7 +41,7 @@ class BusPage extends StatefulWidget {
   @override
   BusPageState createState() => BusPageState();
 
-  const BusPage({Key? key, this.arguments}) : super(key: key);
+  const BusPage({super.key, this.arguments});
 }
 
 class BusPageState extends State<BusPage> {

--- a/lib/page/dashboard/card_detail.dart
+++ b/lib/page/dashboard/card_detail.dart
@@ -39,7 +39,7 @@ class CardDetailPage extends StatefulWidget {
   @override
   CardDetailPageState createState() => CardDetailPageState();
 
-  const CardDetailPage({Key? key, this.arguments}) : super(key: key);
+  const CardDetailPage({super.key, this.arguments});
 }
 
 class CardDetailPageState extends State<CardDetailPage> {

--- a/lib/page/dashboard/card_traffic.dart
+++ b/lib/page/dashboard/card_traffic.dart
@@ -38,7 +38,7 @@ class CardCrowdData extends StatefulWidget {
   @override
   CardCrowdDataState createState() => CardCrowdDataState();
 
-  const CardCrowdData({Key? key, this.arguments}) : super(key: key);
+  const CardCrowdData({super.key, this.arguments});
 }
 
 class CardCrowdDataState extends State<CardCrowdData> {

--- a/lib/page/dashboard/dashboard_reorder.dart
+++ b/lib/page/dashboard/dashboard_reorder.dart
@@ -33,7 +33,7 @@ class DashboardReorderPage extends StatefulWidget {
   /// 'items': A list of [LicenseItem] to display on the page
   final Map<String, dynamic>? arguments;
 
-  const DashboardReorderPage({Key? key, this.arguments}) : super(key: key);
+  const DashboardReorderPage({super.key, this.arguments});
 
   @override
   DashboardReorderPageState createState() => DashboardReorderPageState();

--- a/lib/page/dashboard/empty_classroom_detail.dart
+++ b/lib/page/dashboard/empty_classroom_detail.dart
@@ -46,7 +46,7 @@ class EmptyClassroomDetailPage extends StatefulWidget {
   EmptyClassroomDetailPageState createState() =>
       EmptyClassroomDetailPageState();
 
-  const EmptyClassroomDetailPage({Key? key, this.arguments}) : super(key: key);
+  const EmptyClassroomDetailPage({super.key, this.arguments});
 }
 
 class EmptyClassroomDetailPageState extends State<EmptyClassroomDetailPage> {

--- a/lib/page/dashboard/exam_detail.dart
+++ b/lib/page/dashboard/exam_detail.dart
@@ -50,7 +50,7 @@ class ExamList extends StatefulWidget {
   @override
   ExamListState createState() => ExamListState();
 
-  const ExamList({Key? key, this.arguments}) : super(key: key);
+  const ExamList({super.key, this.arguments});
 }
 
 class ExamListState extends State<ExamList> {

--- a/lib/page/dashboard/gpa_table.dart
+++ b/lib/page/dashboard/gpa_table.dart
@@ -27,7 +27,7 @@ class GpaTablePage extends StatefulWidget {
   @override
   GpaTablePageState createState() => GpaTablePageState();
 
-  const GpaTablePage({Key? key, this.arguments}) : super(key: key);
+  const GpaTablePage({super.key, this.arguments});
 }
 
 class GpaTablePageState extends State<GpaTablePage> {

--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -84,7 +84,7 @@ const QuickActions quickActions = QuickActions();
 /// The main page of DanXi.
 /// It is a container for [PlatformSubpage].
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   HomePageState createState() => HomePageState();

--- a/lib/page/opentreehole/hole_detail.dart
+++ b/lib/page/opentreehole/hole_detail.dart
@@ -104,7 +104,7 @@ String preprocessContentForDisplay(String content) {
 class BBSPostDetail extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const BBSPostDetail({Key? key, this.arguments}) : super(key: key);
+  const BBSPostDetail({super.key, this.arguments});
 
   @override
   BBSPostDetailState createState() => BBSPostDetailState();

--- a/lib/page/opentreehole/hole_editor.dart
+++ b/lib/page/opentreehole/hole_editor.dart
@@ -305,13 +305,12 @@ class BBSEditorWidget extends StatefulWidget {
   final String? tip;
 
   const BBSEditorWidget(
-      {Key? key,
+      {super.key,
       required this.controller,
       this.allowTags,
       this.editorObject,
       this.fullscreen = false,
-      this.tip})
-      : super(key: key);
+      this.tip});
 
   @override
   BBSEditorWidgetState createState() => BBSEditorWidgetState();
@@ -498,8 +497,7 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
 
 class TagSuggestionWidget extends StatefulWidget {
   const TagSuggestionWidget(
-      {Key? key, required this.content, required this.tagSelectorKey})
-      : super(key: key);
+      {super.key, required this.content, required this.tagSelectorKey});
   final String content;
   final GlobalKey<OTTagSelectorState> tagSelectorKey;
 
@@ -595,7 +593,7 @@ class PostEditorText {
 class BBSEditorPage extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const BBSEditorPage({Key? key, this.arguments}) : super(key: key);
+  const BBSEditorPage({super.key, this.arguments});
 
   @override
   BBSEditorPageState createState() => BBSEditorPageState();

--- a/lib/page/opentreehole/hole_login.dart
+++ b/lib/page/opentreehole/hole_login.dart
@@ -41,7 +41,7 @@ class HoleLoginPage extends StatefulWidget {
   @override
   HoleLoginPageState createState() => HoleLoginPageState();
 
-  const HoleLoginPage({Key? key, this.arguments}) : super(key: key);
+  const HoleLoginPage({super.key, this.arguments});
 }
 
 class HoleLoginPageState extends State<HoleLoginPage> {
@@ -139,7 +139,7 @@ abstract class SubStatelessWidget extends StatelessWidget {
   final HoleLoginPageState state;
   final bool backable = true;
 
-  const SubStatelessWidget({Key? key, required this.state}) : super(key: key);
+  const SubStatelessWidget({super.key, required this.state});
 
   Widget buildContent(BuildContext context);
 
@@ -177,8 +177,7 @@ abstract class SubStatelessWidget extends StatelessWidget {
 }
 
 class OTEmailSelectionWidget extends SubStatelessWidget {
-  const OTEmailSelectionWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  const OTEmailSelectionWidget({super.key, required super.state});
 
   /// Check [email] usability.
   ///
@@ -277,8 +276,7 @@ class OTEmailPasswordLoginWidget extends SubStatelessWidget {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
 
-  OTEmailPasswordLoginWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  OTEmailPasswordLoginWidget({super.key, required super.state});
 
   Future<void> executeLogin(BuildContext context) async {
     var model = Provider.of<LoginInfoModel>(context, listen: false);
@@ -395,8 +393,7 @@ class OTLoadingWidget extends SubStatelessWidget {
   @override
   final bool backable = false;
 
-  OTLoadingWidget({required HoleLoginPageState state})
-      : super(key: UniqueKey(), state: state);
+  OTLoadingWidget({required super.state}) : super(key: UniqueKey());
 
   @override
   Widget buildContent(BuildContext context) {
@@ -421,8 +418,7 @@ class OTLoadingWidget extends SubStatelessWidget {
 class OTSetPasswordWidget extends SubStatelessWidget {
   final TextEditingController _passwordController = TextEditingController();
 
-  OTSetPasswordWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  OTSetPasswordWidget({super.key, required super.state});
 
   @override
   Widget buildContent(BuildContext context) {
@@ -469,8 +465,7 @@ class OTSetPasswordWidget extends SubStatelessWidget {
 }
 
 class OTRegisterLicenseWidget extends SubStatelessWidget {
-  const OTRegisterLicenseWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  const OTRegisterLicenseWidget({super.key, required super.state});
 
   static Future<void> executeRegister(
       BuildContext context, HoleLoginPageState state) async {
@@ -522,8 +517,7 @@ class OTRegisterLicenseWidget extends SubStatelessWidget {
 class OTLicenseBody extends StatefulWidget {
   final VoidCallback registerCallback;
 
-  const OTLicenseBody({Key? key, required this.registerCallback})
-      : super(key: key);
+  const OTLicenseBody({super.key, required this.registerCallback});
 
   @override
   OTLicenseBodyState createState() => OTLicenseBodyState();
@@ -567,8 +561,7 @@ class OTLicenseBodyState extends State<OTLicenseBody> {
 class OTEmailVerifyCodeWidget extends SubStatelessWidget {
   final TextEditingController _verifyCodeController = TextEditingController();
 
-  OTEmailVerifyCodeWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  OTEmailVerifyCodeWidget({super.key, required super.state});
 
   @override
   Widget buildContent(BuildContext context) {
@@ -623,8 +616,7 @@ class OTRegisterSuccessWidget extends SubStatelessWidget {
   @override
   final bool backable = false;
 
-  const OTRegisterSuccessWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  const OTRegisterSuccessWidget({super.key, required super.state});
 
   @override
   Widget buildContent(BuildContext context) {
@@ -688,8 +680,7 @@ class OTLoginSuccessWidget extends SubStatelessWidget {
   @override
   final bool backable = false;
 
-  const OTLoginSuccessWidget({Key? key, required HoleLoginPageState state})
-      : super(key: key, state: state);
+  const OTLoginSuccessWidget({super.key, required super.state});
 
   @override
   Widget buildContent(BuildContext context) {

--- a/lib/page/opentreehole/hole_messages.dart
+++ b/lib/page/opentreehole/hole_messages.dart
@@ -34,7 +34,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 class OTMessagesPage extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const OTMessagesPage({Key? key, this.arguments}) : super(key: key);
+  const OTMessagesPage({super.key, this.arguments});
 
   @override
   OTMessagesPageState createState() => OTMessagesPageState();

--- a/lib/page/opentreehole/hole_reports.dart
+++ b/lib/page/opentreehole/hole_reports.dart
@@ -41,7 +41,7 @@ import 'package:flutter_progress_dialog/flutter_progress_dialog.dart';
 class BBSReportDetail extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const BBSReportDetail({Key? key, this.arguments}) : super(key: key);
+  const BBSReportDetail({super.key, this.arguments});
 
   @override
   BBSReportDetailState createState() => BBSReportDetailState();

--- a/lib/page/opentreehole/hole_search.dart
+++ b/lib/page/opentreehole/hole_search.dart
@@ -41,7 +41,7 @@ import 'package:provider/provider.dart';
 class OTSearchPage extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const OTSearchPage({Key? key, this.arguments}) : super(key: key);
+  const OTSearchPage({super.key, this.arguments});
 
   @override
   State<OTSearchPage> createState() => _OTSearchPageState();

--- a/lib/page/opentreehole/hole_tags.dart
+++ b/lib/page/opentreehole/hole_tags.dart
@@ -36,7 +36,7 @@ class BBSTagsPage extends StatefulWidget {
   @override
   BBSTagsPageState createState() => BBSTagsPageState();
 
-  const BBSTagsPage({Key? key, this.arguments}) : super(key: key);
+  const BBSTagsPage({super.key, this.arguments});
 }
 
 class BBSTagsPageState extends State<BBSTagsPage> {

--- a/lib/page/opentreehole/image_viewer.dart
+++ b/lib/page/opentreehole/image_viewer.dart
@@ -68,9 +68,8 @@ class ImageViewerPage extends StatefulWidget {
   @override
   ImageViewerPageState createState() => ImageViewerPageState();
 
-  ImageViewerPage({Key? key, this.arguments})
-      : assert(arguments == null || arguments['hd_url'] != null),
-        super(key: key);
+  ImageViewerPage({super.key, this.arguments})
+      : assert(arguments == null || arguments['hd_url'] != null);
 
   static bool isImage(String url) {
     if (url.isEmpty || Uri.tryParse(url) == null) return false;
@@ -294,8 +293,7 @@ class ImageViewerBodyView extends StatefulWidget {
   final ImageUrlInfo imageInfo;
   final Object? heroTag;
 
-  const ImageViewerBodyView({Key? key, required this.imageInfo, this.heroTag})
-      : super(key: key);
+  const ImageViewerBodyView({super.key, required this.imageInfo, this.heroTag});
 
   @override
   ImageViewerBodyViewState createState() => ImageViewerBodyViewState();

--- a/lib/page/opentreehole/image_viewer.dart
+++ b/lib/page/opentreehole/image_viewer.dart
@@ -30,7 +30,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_cache_manager/src/cache_managers/default_cache_manager.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
-import 'package:gallery_saver/gallery_saver.dart';
+import 'package:gal/gal.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:share_plus/share_plus.dart';
@@ -171,13 +171,13 @@ class ImageViewerPageState extends State<ImageViewerPage> {
       // Attach an extension name for the picture file
       File tempFileWithExtName = await image.copy(image.absolute.path +
           (_guessExtensionNameFromUrl(_imageList[showIndex].hdUrl) ?? ""));
-      bool? result;
+      bool result = false;
       try {
-        result =
-            await GallerySaver.saveImage(tempFileWithExtName.absolute.path);
+        await Gal.putImage(tempFileWithExtName.absolute.path);
+        result = true;
       } catch (_) {}
       if (!mounted) return;
-      if (result != null && result) {
+      if (result) {
         Noticing.showNotice(context, S.of(context).image_save_success);
       } else {
         Noticing.showNotice(context, S.of(context).image_save_failed);

--- a/lib/page/opentreehole/text_selector.dart
+++ b/lib/page/opentreehole/text_selector.dart
@@ -33,7 +33,7 @@ class TextSelectorPage extends StatefulWidget {
   @override
   TextSelectorPageState createState() => TextSelectorPageState();
 
-  const TextSelectorPage({Key? key, this.arguments}) : super(key: key);
+  const TextSelectorPage({super.key, this.arguments});
 }
 
 class TextSelectorPageState extends State<TextSelectorPage> {

--- a/lib/page/platform_subpage.dart
+++ b/lib/page/platform_subpage.dart
@@ -31,7 +31,7 @@ import 'package:provider/provider.dart';
 /// Note: a [PlatformSubpage] must have a parent widget [PageWithTab]. Otherwise, it will
 /// suppose that it is NOT in a tab page, and functions like a empty [Container].
 abstract class PlatformSubpage<T> extends StatefulWidget {
-  const PlatformSubpage({Key? key}) : super(key: key);
+  const PlatformSubpage({super.key});
 
   @deprecated
   final bool needPadding = false;
@@ -55,7 +55,7 @@ abstract class PlatformSubpage<T> extends StatefulWidget {
 class PageWithTab extends StatelessWidget {
   final Widget child;
 
-  const PageWithTab({Key? key, required this.child}) : super(key: key);
+  const PageWithTab({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) => child;

--- a/lib/page/settings/diagnostic_console.dart
+++ b/lib/page/settings/diagnostic_console.dart
@@ -116,6 +116,7 @@ class DiagnosticConsoleState extends State<DiagnosticConsole> {
         "User Agent used by DanXi for UIS: ${UserAgentInterceptor.defaultUsedUserAgent}");
     _console
         .writeln("User Agent used by DanXi for FDUHole: ${Constant.version}");
+    _console.writeln("Media Query: ${MediaQuery.of(context)}");
 
     _console.writeln("Everything we stored in the local device:");
     var allKeys = await context.read<SettingsProvider>().preferences?.getKeys();

--- a/lib/page/settings/diagnostic_console.dart
+++ b/lib/page/settings/diagnostic_console.dart
@@ -38,7 +38,7 @@ import 'package:uuid/uuid.dart';
 class DiagnosticConsole extends StatefulWidget {
   final Map<String, dynamic>? arguments;
 
-  const DiagnosticConsole({Key? key, this.arguments}) : super(key: key);
+  const DiagnosticConsole({super.key, this.arguments});
 
   @override
   DiagnosticConsoleState createState() => DiagnosticConsoleState();

--- a/lib/page/settings/hidden_tags_preference.dart
+++ b/lib/page/settings/hidden_tags_preference.dart
@@ -32,8 +32,7 @@ class BBSHiddenTagsPreferencePage extends StatefulWidget {
   BBSHiddenTagsPreferencePageState createState() =>
       BBSHiddenTagsPreferencePageState();
 
-  const BBSHiddenTagsPreferencePage({Key? key, this.arguments})
-      : super(key: key);
+  const BBSHiddenTagsPreferencePage({super.key, this.arguments});
 }
 
 class BBSHiddenTagsPreferencePageState

--- a/lib/page/settings/open_source_license.dart
+++ b/lib/page/settings/open_source_license.dart
@@ -30,7 +30,7 @@ class OpenSourceLicenseList extends StatefulWidget {
   /// 'items': A list of [LicenseItem] to display on the page
   final Map<String, dynamic>? arguments;
 
-  const OpenSourceLicenseList({Key? key, this.arguments}) : super(key: key);
+  const OpenSourceLicenseList({super.key, this.arguments});
 
   @override
   OpenSourceListState createState() => OpenSourceListState();

--- a/lib/page/subpage_danke.dart
+++ b/lib/page/subpage_danke.dart
@@ -41,7 +41,7 @@ class DankeSubPage extends PlatformSubpage<DankeSubPage> {
   @override
   DankeSubPageState createState() => DankeSubPageState();
 
-  const DankeSubPage({Key? key}) : super(key: key);
+  const DankeSubPage({super.key});
 
   @override
   Create<Widget> get title => (cxt) => Text(S.of(cxt).curriculum);

--- a/lib/page/subpage_dashboard.dart
+++ b/lib/page/subpage_dashboard.dart
@@ -45,7 +45,7 @@ class HomeSubpage extends PlatformSubpage<HomeSubpage> {
   @override
   HomeSubpageState createState() => HomeSubpageState();
 
-  const HomeSubpage({Key? key}) : super(key: key);
+  const HomeSubpage({super.key});
 
   @override
   Create<Widget> get title => (cxt) => Text(S.of(cxt).dashboard);

--- a/lib/page/subpage_settings.dart
+++ b/lib/page/subpage_settings.dart
@@ -75,7 +75,7 @@ class SettingsSubpage extends PlatformSubpage<SettingsSubpage> {
   @override
   SettingsSubpageState createState() => SettingsSubpageState();
 
-  const SettingsSubpage({Key? key}) : super(key: key);
+  const SettingsSubpage({super.key});
 
   @override
   Create<Widget> get title => (cxt) => Text(S.of(cxt).settings);
@@ -1132,7 +1132,7 @@ class Developer {
 }
 
 class OTNotificationSettingsWidget extends StatefulWidget {
-  const OTNotificationSettingsWidget({Key? key}) : super(key: key);
+  const OTNotificationSettingsWidget({super.key});
 
   @override
   State<OTNotificationSettingsWidget> createState() =>
@@ -1180,8 +1180,7 @@ class _OTNotificationSettingsWidgetState
 class OTNotificationSettingsTile extends StatelessWidget {
   final void Function() onSettingsUpdate;
 
-  const OTNotificationSettingsTile({Key? key, required this.onSettingsUpdate})
-      : super(key: key);
+  const OTNotificationSettingsTile({super.key, required this.onSettingsUpdate});
 
   String _generateNotificationSettingsSummary(
       BuildContext context, List<String>? data) {

--- a/lib/page/subpage_timetable.dart
+++ b/lib/page/subpage_timetable.dart
@@ -70,7 +70,7 @@ class TimetableSubPage extends PlatformSubpage<TimetableSubPage> {
   @override
   TimetableSubPageState createState() => TimetableSubPageState();
 
-  const TimetableSubPage({Key? key}) : super(key: key);
+  const TimetableSubPage({super.key});
 
   @override
   Create<Widget> get title => (cxt) => Text(S.of(cxt).timetable);
@@ -554,8 +554,7 @@ class TimetableSubPageState extends PlatformSubpageState<TimetableSubPage> {
 class SemesterSelectionButton extends StatefulWidget {
   final void Function()? onSelectionUpdate;
 
-  const SemesterSelectionButton({Key? key, this.onSelectionUpdate})
-      : super(key: key);
+  const SemesterSelectionButton({super.key, this.onSelectionUpdate});
 
   @override
   SemesterSelectionButtonState createState() => SemesterSelectionButtonState();
@@ -655,7 +654,7 @@ class SemesterSelectionButtonState extends State<SemesterSelectionButton> {
 }
 
 class StartDateSelectionButton extends StatelessWidget {
-  const StartDateSelectionButton({Key? key, this.onUpdate}) : super(key: key);
+  const StartDateSelectionButton({super.key, this.onUpdate});
 
   final void Function()? onUpdate;
 

--- a/lib/page/subpage_treehole.dart
+++ b/lib/page/subpage_treehole.dart
@@ -53,9 +53,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:intl/intl.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:provider/provider.dart';
-import 'package:intl/intl.dart';
 
 import '../util/watermark.dart';
 import '../widget/opentreehole/tag_selector/tag.dart';
@@ -149,7 +149,7 @@ const String KEY_NO_TAG = "默认";
 
 /// The tab bar for switching divisions.
 class OTTitle extends StatelessWidget {
-  const OTTitle({Key? key}) : super(key: key);
+  const OTTitle({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -189,7 +189,7 @@ class TreeHoleSubpage extends PlatformSubpage<TreeHoleSubpage> {
   @override
   TreeHoleSubpageState createState() => TreeHoleSubpageState();
 
-  const TreeHoleSubpage({Key? key, this.arguments}) : super(key: key);
+  const TreeHoleSubpage({super.key, this.arguments});
 
   @override
   Create<List<AppBarButtonItem>> get leading => (cxt) => [

--- a/lib/util/animation.dart
+++ b/lib/util/animation.dart
@@ -6,11 +6,11 @@ import 'package:flutter/material.dart';
 
 class MySlideTransition extends AnimatedWidget {
   const MySlideTransition({
-    Key? key,
+    super.key,
     required Animation<Offset> position,
     this.transformHitTests = true,
     required this.child,
-  }) : super(key: key, listenable: position);
+  }) : super(listenable: position);
 
   Animation<Offset> get position => listenable as Animation<Offset>;
   final bool transformHitTests;

--- a/lib/util/master_detail_view.dart
+++ b/lib/util/master_detail_view.dart
@@ -28,8 +28,7 @@ class PlatformMasterDetailApp extends StatelessWidget {
   final GlobalKey<NavigatorState>? navigatorKey;
 
   const PlatformMasterDetailApp(
-      {Key? key, this.onGenerateRoute, this.navigatorKey})
-      : super(key: key);
+      {super.key, this.onGenerateRoute, this.navigatorKey});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/danke/course_list_widget.dart
+++ b/lib/widget/danke/course_list_widget.dart
@@ -34,7 +34,7 @@ class CourseListWidget extends StatefulWidget {
 
   final String? searchKeyword;
 
-  const CourseListWidget({Key? key, this.searchKeyword}) : super(key: key);
+  const CourseListWidget({super.key, this.searchKeyword});
 }
 
 class CourseListWidgetState extends State<CourseListWidget> {

--- a/lib/widget/danke/course_review_widget.dart
+++ b/lib/widget/danke/course_review_widget.dart
@@ -37,11 +37,11 @@ class CourseReviewWidget extends StatelessWidget {
   final bool translucent;
 
   const CourseReviewWidget(
-      {Key? key,
+      {super.key,
       required this.review,
       required this.courseGroup,
-      this.translucent = false, this.reviewOperationCallback})
-      : super(key: key);
+      this.translucent = false,
+      this.reviewOperationCallback});
 
   @override
   Widget build(BuildContext context) {
@@ -149,12 +149,11 @@ class ReviewHeader extends StatelessWidget {
   // final String reviewContent;
 
   const ReviewHeader(
-      {Key? key,
+      {super.key,
       required this.userId,
       required this.teacher,
       required this.time,
-      required this.title})
-      : super(key: key);
+      required this.title});
 
   @override
   Widget build(BuildContext context) {
@@ -223,12 +222,11 @@ class ReviewHeader extends StatelessWidget {
 
 class ReviewFooter extends StatelessWidget {
   const ReviewFooter(
-      {Key? key,
+      {super.key,
       required this.overallLevel,
       required this.styleLevel,
       required this.workloadLevel,
-      required this.assessmentLevel})
-      : super(key: key);
+      required this.assessmentLevel});
 
   final int overallLevel;
   final int styleLevel;

--- a/lib/widget/danke/course_search_bar.dart
+++ b/lib/widget/danke/course_search_bar.dart
@@ -23,8 +23,8 @@ class CourseSearchBar extends StatefulWidget {
   final Function(String) onSearch;
   final void Function(bool)? onFocusChanged;
 
-  const CourseSearchBar({Key? key, required this.onSearch, this.onFocusChanged})
-      : super(key: key);
+  const CourseSearchBar(
+      {super.key, required this.onSearch, this.onFocusChanged});
 
   @override
   _CourseSearchBarState createState() => _CourseSearchBarState();

--- a/lib/widget/danke/course_widgets.dart
+++ b/lib/widget/danke/course_widgets.dart
@@ -37,8 +37,7 @@ class CourseGroupCardWidget extends StatelessWidget {
   final CourseGroup courseGroup;
 
   const CourseGroupCardWidget(
-      {Key? key, required this.courseGroup, this.translucent = false})
-      : super(key: key);
+      {super.key, required this.courseGroup, this.translucent = false});
 
   @override
   Widget build(BuildContext context) {
@@ -165,8 +164,10 @@ class FilterTagWidget extends StatelessWidget {
   final void Function() onTap;
 
   const FilterTagWidget(
-      {Key? key, required this.color, required this.text, required this.onTap})
-      : super(key: key);
+      {super.key,
+      required this.color,
+      required this.text,
+      required this.onTap});
 
   @override
   Widget build(BuildContext context) => RoundChip(

--- a/lib/widget/danke/random_review_widgets.dart
+++ b/lib/widget/danke/random_review_widgets.dart
@@ -30,8 +30,7 @@ class RandomReviewWidgets extends StatelessWidget {
   final CourseReview review;
 
   const RandomReviewWidgets(
-      {Key? key, required this.review, this.translucent = false, this.onTap})
-      : super(key: key);
+      {super.key, required this.review, this.translucent = false, this.onTap});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/danke/review_vote_widget.dart
+++ b/lib/widget/danke/review_vote_widget.dart
@@ -24,11 +24,10 @@ import 'package:flutter/material.dart';
 
 class ReviewVoteWidget extends StatefulWidget {
   const ReviewVoteWidget(
-      {Key? key,
+      {super.key,
       required this.myVote,
       required this.reviewVote,
-      required this.reviewId})
-      : super(key: key);
+      required this.reviewId});
 
   final int reviewVote;
   final int myVote;

--- a/lib/widget/dialogs/care_dialog.dart
+++ b/lib/widget/dialogs/care_dialog.dart
@@ -8,7 +8,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import '../../generated/l10n.dart';
 
 class CareDialog extends StatefulWidget {
-  const CareDialog({Key? key}) : super(key: key);
+  const CareDialog({super.key});
 
   @override
   State<CareDialog> createState() => _CareDialogState();

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -69,11 +69,10 @@ class LoginDialog extends StatefulWidget {
   }
 
   const LoginDialog(
-      {Key? key,
+      {super.key,
       required this.sharedPreferences,
       required this.personInfo,
-      required this.dismissible})
-      : super(key: key);
+      required this.dismissible});
 
   @override
   LoginDialogState createState() => LoginDialogState();

--- a/lib/widget/dialogs/manually_add_course_dialog.dart
+++ b/lib/widget/dialogs/manually_add_course_dialog.dart
@@ -10,8 +10,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:provider/provider.dart';
 
 class ManuallyAddCourseDialog extends StatefulWidget {
-  const ManuallyAddCourseDialog(this.courseAvailableList, {Key? key})
-      : super(key: key);
+  const ManuallyAddCourseDialog(this.courseAvailableList, {super.key});
 
   final List<int> courseAvailableList;
 

--- a/lib/widget/dialogs/manually_add_course_dialog_sub.dart
+++ b/lib/widget/dialogs/manually_add_course_dialog_sub.dart
@@ -3,15 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:provider/provider.dart';
 
-import '../../generated/l10n.dart';
 import '../../common/constant.dart';
+import '../../generated/l10n.dart';
 import '../../model/time_table.dart';
 import '../../provider/settings_provider.dart';
 import '../../util/platform_universal.dart';
 
 class AddCourseDialogSub extends StatefulWidget {
-  const AddCourseDialogSub({Key? key})
-      : super(key: key);
+  const AddCourseDialogSub({super.key});
+
   @override
   State<AddCourseDialogSub> createState() => _AddCourseDialogSubState();
 }

--- a/lib/widget/dialogs/new_shortcut_widget_dialog.dart
+++ b/lib/widget/dialogs/new_shortcut_widget_dialog.dart
@@ -29,8 +29,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 /// Allows user to create custom dashboard widgets that link to certain websites.
 class NewShortcutDialog extends StatefulWidget {
 
-  const NewShortcutDialog({
-    Key? key}) : super(key: key);
+  const NewShortcutDialog({super.key});
 
   @override
   NewShortcutDialogState createState() => NewShortcutDialogState();

--- a/lib/widget/dialogs/qr_code_dialog.dart
+++ b/lib/widget/dialogs/qr_code_dialog.dart
@@ -50,7 +50,7 @@ class QRHelper {
 class QRDialog extends StatefulWidget {
   final PersonInfo? personInfo;
 
-  const QRDialog({Key? key, this.personInfo}) : super(key: key);
+  const QRDialog({super.key, this.personInfo});
 
   @override
   QRDialogState createState() => QRDialogState();

--- a/lib/widget/dialogs/swatch_picker_dialog.dart
+++ b/lib/widget/dialogs/swatch_picker_dialog.dart
@@ -26,8 +26,7 @@ import 'package:material_color_generator/material_color_generator.dart';
 class SwatchPickerDialog extends StatefulWidget {
   final int initialSelectedColor;
 
-  const SwatchPickerDialog({Key? key, required this.initialSelectedColor})
-      : super(key: key);
+  const SwatchPickerDialog({super.key, required this.initialSelectedColor});
 
   @override
   State<SwatchPickerDialog> createState() => _SwatchPickerDialogState();

--- a/lib/widget/feature_item/feature_card_item.dart
+++ b/lib/widget/feature_item/feature_card_item.dart
@@ -31,8 +31,7 @@ class FeatureCardItem extends StatefulWidget implements FeatureContainer {
   FeatureCardItemState createState() => FeatureCardItemState();
 
   const FeatureCardItem(
-      {required this.feature, this.arguments, this.onDismissed, Key? key})
-      : super(key: key);
+      {required this.feature, this.arguments, this.onDismissed, super.key});
 
   @override
   Feature get childFeature => feature;

--- a/lib/widget/feature_item/feature_list_item.dart
+++ b/lib/widget/feature_item/feature_list_item.dart
@@ -28,8 +28,7 @@ class FeatureListItem extends StatefulWidget implements FeatureContainer {
   @override
   FeatureListItemState createState() => FeatureListItemState();
 
-  const FeatureListItem({required this.feature, this.arguments, Key? key})
-      : super(key: key);
+  const FeatureListItem({required this.feature, this.arguments, super.key});
 
   @override
   Feature get childFeature => feature;

--- a/lib/widget/feature_item/feature_progress_indicator.dart
+++ b/lib/widget/feature_item/feature_progress_indicator.dart
@@ -25,7 +25,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 ///
 /// It is commonly used in [Feature] to indicate that the feature is loading.
 class FeatureProgressIndicator extends StatelessWidget {
-  const FeatureProgressIndicator({Key? key}) : super(key: key);
+  const FeatureProgressIndicator({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/dynamic_theme.dart
+++ b/lib/widget/libraries/dynamic_theme.dart
@@ -28,11 +28,10 @@ class DynamicThemeController extends StatefulWidget {
   final ThemeData darkTheme;
 
   const DynamicThemeController(
-      {Key? key,
+      {super.key,
       required this.child,
       required this.lightTheme,
-      required this.darkTheme})
-      : super(key: key);
+      required this.darkTheme});
 
   @override
   DynamicThemeControllerState createState() => DynamicThemeControllerState();
@@ -85,7 +84,7 @@ class DynamicThemeControllerState extends State<DynamicThemeController>
 class ThemedSystemOverlay extends StatelessWidget {
   final Widget child;
 
-  const ThemedSystemOverlay({Key? key, required this.child}) : super(key: key);
+  const ThemedSystemOverlay({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/error_page_widget.dart
+++ b/lib/widget/libraries/error_page_widget.dart
@@ -34,14 +34,13 @@ class ErrorPageWidget extends StatelessWidget {
   final VoidCallback? onTap;
 
   const ErrorPageWidget(
-      {Key? key,
+      {super.key,
       this.icon,
       required this.buttonText,
       required this.errorMessage,
       this.onTap,
       this.error,
-      this.trace})
-      : super(key: key);
+      this.trace});
 
   /// Try to parse error information from [error].
   static String generateUserFriendlyDescription(S locale, dynamic error,

--- a/lib/widget/libraries/future_widget.dart
+++ b/lib/widget/libraries/future_widget.dart
@@ -23,14 +23,13 @@ import 'package:flutter/material.dart';
 /// which will build different widgets depending on different states: See [ConnectionState.values].
 class FutureWidget<T> extends StatefulWidget {
   const FutureWidget(
-      {Key? key,
+      {super.key,
       this.initialData,
       required this.future,
       required this.successBuilder,
       required this.errorBuilder,
       required this.loadingBuilder,
-      this.nullable = false})
-      : super(key: key);
+      this.nullable = false});
   final dynamic errorBuilder;
   final dynamic loadingBuilder;
   final Future<T>? future;

--- a/lib/widget/libraries/linkify_x.dart
+++ b/lib/widget/libraries/linkify_x.dart
@@ -25,44 +25,29 @@ import 'package:flutter_linkify/flutter_linkify.dart';
 /// have to create a new class to override it.
 class LinkifyX extends Linkify {
   const LinkifyX({
-    Key? key,
-    required String text,
-    void Function(LinkableElement)? onOpen,
-    TextAlign textAlign = TextAlign.start,
-    double textScaleFactor = 1.0,
-    int? maxLines,
-    TextOverflow overflow = TextOverflow.clip,
-    TextStyle? style,
+    super.key,
+    required super.text,
+    super.onOpen,
+    super.textAlign,
+    super.textScaleFactor,
+    super.maxLines,
+    TextOverflow super.overflow,
+    super.style,
   }) : super(
-          key: key,
-          text: text,
           linkStyle: Constant.LINKIFY_THEME,
-          onOpen: onOpen,
-          textAlign: textAlign,
-          textScaleFactor: textScaleFactor,
-          maxLines: maxLines,
-          overflow: overflow,
-          style: style,
         );
 }
 
 class SelectableLinkifyX extends SelectableLinkify {
   const SelectableLinkifyX({
-    Key? key,
-    required String text,
-    void Function(LinkableElement)? onOpen,
-    TextAlign textAlign = TextAlign.start,
-    double textScaleFactor = 1.0,
-    int? maxLines,
-    TextStyle? style,
+    super.key,
+    required super.text,
+    super.onOpen,
+    TextAlign super.textAlign = TextAlign.start,
+    super.textScaleFactor,
+    super.maxLines,
+    super.style,
   }) : super(
-          key: key,
-          text: text,
           linkStyle: Constant.LINKIFY_THEME,
-          onOpen: onOpen,
-          textAlign: textAlign,
-          textScaleFactor: textScaleFactor,
-          maxLines: maxLines,
-          style: style,
         );
 }

--- a/lib/widget/libraries/material_banner.dart
+++ b/lib/widget/libraries/material_banner.dart
@@ -29,15 +29,14 @@ class SlimMaterialBanner extends StatelessWidget {
   final bool dismissible;
 
   const SlimMaterialBanner(
-      {Key? key,
+      {super.key,
       this.icon,
       required this.title,
       this.actionName,
       this.onTapAction,
       this.dismissible = false,
       this.onDismissed})
-      : assert(!dismissible || key != null),
-        super(key: key);
+      : assert(!dismissible || key != null);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/material_x.dart
+++ b/lib/widget/libraries/material_x.dart
@@ -22,7 +22,7 @@ class ExpansionTileX extends StatefulWidget {
   /// the tile to reveal or hide the [children]. The [initiallyExpanded] property must
   /// be non-null.
   const ExpansionTileX({
-    Key? key,
+    super.key,
     this.leading,
     required this.title,
     this.subtitle,
@@ -42,12 +42,11 @@ class ExpansionTileX extends StatefulWidget {
     this.iconColor,
     this.collapsedIconColor,
     this.controlAffinity,
-  })  : assert(
+  }) : assert(
           expandedCrossAxisAlignment != CrossAxisAlignment.baseline,
           'CrossAxisAlignment.baseline is not supported since the expanded children '
           'are aligned in a column, not a row. Try to use another constant.',
-        ),
-        super(key: key);
+        );
 
   /// A widget to display before the title.
   ///

--- a/lib/widget/libraries/paged_listview.dart
+++ b/lib/widget/libraries/paged_listview.dart
@@ -100,7 +100,7 @@ class PagedListView<T> extends StatefulWidget {
   final Future<bool?> Function(BuildContext, int, T)? onConfirmDismissItem;
 
   const PagedListView(
-      {Key? key,
+      {super.key,
       this.pagedController,
       this.initialData,
       required this.builder,
@@ -120,8 +120,7 @@ class PagedListView<T> extends StatefulWidget {
       this.onDismissItem,
       this.onConfirmDismissItem})
       : assert((!withScrollbar) || (withScrollbar && scrollController != null)),
-        assert(dataReceiver != null || allDataReceiver != null),
-        super(key: key);
+        assert(dataReceiver != null || allDataReceiver != null);
 
   @override
   PagedListViewState<T> createState() => PagedListViewState<T>();

--- a/lib/widget/libraries/platform_app_bar_ex.dart
+++ b/lib/widget/libraries/platform_app_bar_ex.dart
@@ -51,7 +51,7 @@ class PlatformAppBarX extends PlatformAppBar {
   final PlatformBuilder<CupertinoNavigationBarData>? cupertino;
 
   PlatformAppBarX({
-    Key? key,
+    super.key,
     this.widgetKey,
     this.title,
     this.backgroundColor,
@@ -60,7 +60,7 @@ class PlatformAppBarX extends PlatformAppBar {
     this.automaticallyImplyLeading,
     this.material,
     this.cupertino,
-  }) : super(key: key);
+  });
 
   @override
   PreferredSizeWidget createMaterialWidget(BuildContext context) {

--- a/lib/widget/libraries/platform_context_menu.dart
+++ b/lib/widget/libraries/platform_context_menu.dart
@@ -24,8 +24,7 @@ class PlatformContextMenu extends StatelessWidget {
   final List<Widget> actions;
 
   const PlatformContextMenu(
-      {Key? key, this.cancelButton, required this.actions})
-      : super(key: key);
+      {super.key, this.cancelButton, required this.actions});
 
   @override
   Widget build(BuildContext context) {
@@ -50,12 +49,11 @@ class PlatformContextMenuItem extends StatelessWidget {
   final Widget child;
 
   const PlatformContextMenuItem(
-      {Key? key,
+      {super.key,
       required this.menuContext,
       this.onPressed,
       required this.child,
-      this.isDestructive = false})
-      : super(key: key);
+      this.isDestructive = false});
 
   @override
   Widget build(BuildContext context) {
@@ -92,8 +90,8 @@ class PlatformPopupMenuX extends StatelessWidget {
     required this.icon,
     this.cupertino,
     this.material,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/platform_nav_bar_m3.dart
+++ b/lib/widget/libraries/platform_nav_bar_m3.dart
@@ -37,7 +37,7 @@ class PlatformNavBarM3 extends PlatformNavBar {
   final PlatformBuilder<CupertinoTabBarData>? cupertino;
 
   PlatformNavBarM3({
-    Key? key,
+    super.key,
     this.widgetKey,
     this.backgroundColor,
     this.items,
@@ -46,7 +46,6 @@ class PlatformNavBarM3 extends PlatformNavBar {
     this.material,
     this.cupertino,
   }) : super(
-          key: key,
           widgetKey: widgetKey,
           backgroundColor: backgroundColor,
           items: items,

--- a/lib/widget/libraries/round_chip.dart
+++ b/lib/widget/libraries/round_chip.dart
@@ -24,8 +24,7 @@ class RoundChip extends StatelessWidget {
   final VoidCallback? onTap;
   final Color? color;
 
-  const RoundChip({Key? key, this.label, this.onTap, this.color})
-      : super(key: key);
+  const RoundChip({super.key, this.label, this.onTap, this.color});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/scale_transform.dart
+++ b/lib/widget/libraries/scale_transform.dart
@@ -22,7 +22,7 @@ class ScaleTransform extends StatelessWidget {
   final Widget? child;
   final double? scale;
 
-  const ScaleTransform({Key? key, this.scale, this.child}) : super(key: key);
+  const ScaleTransform({super.key, this.scale, this.child});
 
   @override
   Widget build(BuildContext context) => Transform(

--- a/lib/widget/libraries/sized_by_child_builder.dart
+++ b/lib/widget/libraries/sized_by_child_builder.dart
@@ -25,8 +25,7 @@ class SizedByChildBuilder extends StatefulWidget {
   final Widget Function(BuildContext, Size) builder;
 
   const SizedByChildBuilder(
-      {Key? key, required this.child, required this.builder})
-      : super(key: key);
+      {super.key, required this.child, required this.builder});
 
   @override
   State<SizedByChildBuilder> createState() => _SizedByChildBuilderState();

--- a/lib/widget/libraries/small_tag.dart
+++ b/lib/widget/libraries/small_tag.dart
@@ -24,7 +24,7 @@ import 'package:flutter/material.dart';
 class SmallTag extends StatelessWidget {
   final String? label;
 
-  const SmallTag({Key? key, this.label}) : super(key: key);
+  const SmallTag({super.key, this.label});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/libraries/state_key.dart
+++ b/lib/widget/libraries/state_key.dart
@@ -25,14 +25,14 @@ import 'package:flutter/cupertino.dart';
 class StateKey<T> extends ValueKey<T> {
   late BuildContext currentContext;
 
-  StateKey(T value) : super(value);
+  StateKey(super.value);
 }
 
 class WithStateKey<T> extends StatefulWidget {
   final StateKey<T>? childKey;
   final Widget? child;
 
-  const WithStateKey({Key? key, this.childKey, this.child}) : super(key: key);
+  const WithStateKey({super.key, this.childKey, this.child});
 
   @override
   WithStateKeyState<T> createState() => WithStateKeyState<T>();

--- a/lib/widget/libraries/top_controller.dart
+++ b/lib/widget/libraries/top_controller.dart
@@ -27,8 +27,8 @@ class TopController extends StatelessWidget {
   final ScrollController? controller;
   final Function? onDoubleTap;
 
-  const TopController({Key? key, this.controller, this.onDoubleTap, this.child})
-      : super(key: key);
+  const TopController(
+      {super.key, this.controller, this.onDoubleTap, this.child});
 
   static scrollToTop(ScrollController? controller) =>
       controller?.animateTo(-controller.initialScrollOffset,

--- a/lib/widget/libraries/with_scrollbar.dart
+++ b/lib/widget/libraries/with_scrollbar.dart
@@ -25,8 +25,7 @@ class WithScrollbar extends StatelessWidget {
   final ScrollController? controller;
   final Widget? child;
 
-  const WithScrollbar({Key? key, this.controller, this.child})
-      : super(key: key);
+  const WithScrollbar({super.key, this.controller, this.child});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/opentreehole/auto_banner.dart
+++ b/lib/widget/opentreehole/auto_banner.dart
@@ -35,11 +35,10 @@ class AutoBanner extends StatefulWidget {
   final int maxDisplay;
 
   const AutoBanner(
-      {Key? key,
+      {super.key,
       required this.refreshDuration,
       this.onExpand,
-      this.maxDisplay = 5})
-      : super(key: key);
+      this.maxDisplay = 5});
 
   @override
   State<AutoBanner> createState() => AutoBannerState();

--- a/lib/widget/opentreehole/auto_bbs_image.dart
+++ b/lib/widget/opentreehole/auto_bbs_image.dart
@@ -26,8 +26,7 @@ class BBSImagePlaceholder extends StatelessWidget {
   final Widget? child;
   final double? size;
 
-  const BBSImagePlaceholder({Key? key, this.child, this.size})
-      : super(key: key);
+  const BBSImagePlaceholder({super.key, this.child, this.size});
 
   @override
   Widget build(BuildContext context) {
@@ -53,8 +52,7 @@ class AutoBBSImage extends StatelessWidget {
   final double? maxWidth;
   final ImageTapCallback? onTapImage;
 
-  AutoBBSImage({Key? key, required this.src, this.maxWidth, this.onTapImage})
-      : super(key: key);
+  AutoBBSImage({super.key, required this.src, this.maxWidth, this.onTapImage});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/opentreehole/bbs_tags_container.dart
+++ b/lib/widget/opentreehole/bbs_tags_container.dart
@@ -25,8 +25,7 @@ class BBSTagsContainer extends StatefulWidget {
   final List<OTTag>? tags;
   final OnTapTag? onTap;
 
-  const BBSTagsContainer({Key? key, required this.tags, this.onTap})
-      : super(key: key);
+  const BBSTagsContainer({super.key, required this.tags, this.onTap});
 
   @override
   BBSTagsContainerState createState() => BBSTagsContainerState();

--- a/lib/widget/opentreehole/fake_search_widget.dart
+++ b/lib/widget/opentreehole/fake_search_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 
 class FakeCupertinoSearchTextField extends StatelessWidget {
   FakeCupertinoSearchTextField({
-    Key? key,
+    super.key,
     this.controller,
     this.onChanged,
     this.onSubmitted,
@@ -27,7 +27,7 @@ class FakeCupertinoSearchTextField extends StatelessWidget {
     this.onTap,
     this.autocorrect = true,
     this.enabled,
-  }) : super(key: key);
+  });
 
   /// Controls the text being edited.
   ///

--- a/lib/widget/opentreehole/flutter_watermark_widget.dart
+++ b/lib/widget/opentreehole/flutter_watermark_widget.dart
@@ -27,11 +27,11 @@ class FullScreenWatermark extends StatelessWidget {
   final TextStyle textStyle;
 
   const FullScreenWatermark({
-    Key? key,
+    super.key,
     required this.rowCount,
     required this.columnCount,
     required this.textStyle,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/opentreehole/horizontal_selector.dart
+++ b/lib/widget/opentreehole/horizontal_selector.dart
@@ -26,11 +26,10 @@ class HorizontalSelector<T> extends StatelessWidget {
   final void Function(T)? onSelect;
 
   const HorizontalSelector(
-      {Key? key,
+      {super.key,
       required this.options,
       this.onSelect,
-      required this.selectedOption})
-      : super(key: key);
+      required this.selectedOption});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/opentreehole/login_widgets.dart
+++ b/lib/widget/opentreehole/login_widgets.dart
@@ -25,8 +25,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 class OTWelcomeWidget extends StatelessWidget {
   final void Function() loginCallback;
 
-  const OTWelcomeWidget({Key? key, required this.loginCallback})
-      : super(key: key);
+  const OTWelcomeWidget({super.key, required this.loginCallback});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widget/opentreehole/ottag_selector.dart
+++ b/lib/widget/opentreehole/ottag_selector.dart
@@ -37,8 +37,7 @@ class OTTagSelector extends StatefulWidget {
   final List<OTTag> initialTags;
   final VoidCallback? onChanged;
 
-  const OTTagSelector({Key? key, required this.initialTags, this.onChanged})
-      : super(key: key);
+  const OTTagSelector({super.key, required this.initialTags, this.onChanged});
 
   @override
   OTTagSelectorState createState() => OTTagSelectorState();

--- a/lib/widget/opentreehole/post_render.dart
+++ b/lib/widget/opentreehole/post_render.dart
@@ -27,14 +27,13 @@ class PostRenderWidget extends StatelessWidget {
   final bool isPreviewWidget;
 
   const PostRenderWidget(
-      {Key? key,
+      {super.key,
       required this.content,
       required this.render,
       this.onTapImage,
       this.onTapLink,
       required this.hasBackgroundImage,
-      this.isPreviewWidget = false})
-      : super(key: key);
+      this.isPreviewWidget = false});
 
   @override
   Widget build(BuildContext context) => render.call(context, content,

--- a/lib/widget/opentreehole/tag_selector/flutter_tagging/tagging.dart
+++ b/lib/widget/opentreehole/tag_selector/flutter_tagging/tagging.dart
@@ -159,9 +159,8 @@ class FlutterTagging<T extends Taggable> extends StatefulWidget {
       this.animationDuration = const Duration(milliseconds: 500),
       this.animationStart = 0.25,
       this.onAdded,
-      Key? key,
-      this.customChipBuilder})
-      : super(key: key);
+      super.key,
+      this.customChipBuilder});
 
   @override
   FlutterTaggingState<T> createState() => FlutterTaggingState<T>();

--- a/lib/widget/opentreehole/tag_selector/flutter_tagging/tagging.dart
+++ b/lib/widget/opentreehole/tag_selector/flutter_tagging/tagging.dart
@@ -194,6 +194,7 @@ class FlutterTaggingState<T extends Taggable> extends State<FlutterTagging<T>> {
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         TypeAheadField<T>(
+          ignoreAccessibleNavigation: true,
           getImmediateSuggestions: widget.enableImmediateSuggestion,
           debounceDuration: widget.debounceDuration,
           hideOnEmpty: widget.hideOnEmpty,

--- a/lib/widget/opentreehole/tag_selector/selector.dart
+++ b/lib/widget/opentreehole/tag_selector/selector.dart
@@ -61,7 +61,7 @@ class TagContainer extends StatefulWidget {
   final bool wrapped;
 
   const TagContainer(
-      {Key? key,
+      {super.key,
       required this.tagList,
       required this.fillRandomColor,
       this.singleChoice = false,
@@ -75,8 +75,7 @@ class TagContainer extends StatefulWidget {
       this.wrapped = true})
       : assert(
             fillRandomColor || (fillRandomColor == false && fixedColor != null),
-            "fixedColor can't be empty."),
-        super(key: key);
+            "fixedColor can't be empty.");
 
   @override
   TagContainerState createState() => TagContainerState();

--- a/lib/widget/opentreehole/treehole_widgets.dart
+++ b/lib/widget/opentreehole/treehole_widgets.dart
@@ -73,8 +73,7 @@ class OTLeadingTag extends StatelessWidget {
   final Color color;
   final String text;
 
-  const OTLeadingTag({Key? key, required this.color, this.text = "DZ"})
-      : super(key: key);
+  const OTLeadingTag({super.key, required this.color, this.text = "DZ"});
 
   @override
   Widget build(BuildContext context) {
@@ -128,12 +127,11 @@ class OTHoleWidget extends StatelessWidget {
   final bool isFolded;
 
   const OTHoleWidget(
-      {Key? key,
+      {super.key,
       required this.postElement,
       this.translucent = false,
       this.isPinned = false,
-      this.isFolded = false})
-      : super(key: key);
+      this.isFolded = false});
 
   @override
   Widget build(BuildContext context) {
@@ -349,7 +347,7 @@ class OTFloorWidget extends StatelessWidget {
   final String? searchKeyWord;
 
   const OTFloorWidget({
-    Key? key,
+    super.key,
     required this.floor,
     this.isInMention = false,
     this.showBottomBar = true,
@@ -360,7 +358,7 @@ class OTFloorWidget extends StatelessWidget {
     required this.hasBackgroundImage,
     this.onTapImage,
     this.searchKeyWord,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -561,12 +559,12 @@ class OTMentionPreviewWidget extends StatefulWidget {
   final bool hasBackgroundImage;
 
   const OTMentionPreviewWidget({
-    Key? key,
+    super.key,
     required this.id,
     required this.type,
     this.showBottomBar = false,
     required this.hasBackgroundImage,
-  }) : super(key: key);
+  });
 
   @override
   OTMentionPreviewWidgetState createState() => OTMentionPreviewWidgetState();
@@ -612,11 +610,11 @@ class OTFloorMentionWidget extends StatelessWidget {
   final bool hasBackgroundImage;
 
   const OTFloorMentionWidget({
-    Key? key,
+    super.key,
     required this.future,
     this.showBottomBar = false,
     required this.hasBackgroundImage,
-  }) : super(key: key);
+  });
 
   static Future<bool?> showFloorDetail(BuildContext context, OTFloor floor,
       [String? extraTips]) {
@@ -759,8 +757,7 @@ class OTFloorWidgetBottomBar extends StatefulWidget {
   final int? index;
 
   const OTFloorWidgetBottomBar(
-      {Key? key, required this.floor, required this.index})
-      : super(key: key);
+      {super.key, required this.floor, required this.index});
 
   @override
   OTFloorWidgetBottomBarState createState() => OTFloorWidgetBottomBarState();
@@ -979,8 +976,7 @@ class OTFloorWidgetBottomBarButton extends StatelessWidget {
   final Icon icon;
 
   const OTFloorWidgetBottomBarButton(
-      {Key? key, this.onTap, required this.text, required this.icon})
-      : super(key: key);
+      {super.key, this.onTap, required this.text, required this.icon});
 
   @override
   Widget build(BuildContext context) {
@@ -1009,7 +1005,7 @@ class OTFloorWidgetBottomBarButton extends StatelessWidget {
 class OTMessageItem extends StatefulWidget {
   final OTMessage message;
 
-  const OTMessageItem({Key? key, required this.message}) : super(key: key);
+  const OTMessageItem({super.key, required this.message});
 
   static Future<void> markMessageAsRead(OTMessage message) async {
     if (message.has_read == true) return;

--- a/lib/widget/time_table/schedule_view.dart
+++ b/lib/widget/time_table/schedule_view.dart
@@ -41,8 +41,7 @@ class ScheduleView extends StatefulWidget {
 
   const ScheduleView(
       this.laneEventsList, this.timetableStyle, this.today, this.showingWeek,
-      {Key? key, this.tapCallback})
-      : super(key: key);
+      {super.key, this.tapCallback});
 
   @override
   ScheduleViewState createState() => ScheduleViewState();

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,7 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
+#include <bitsdojo_window_linux_v3/bitsdojo_window_plugin.h>
 #include <desktop_window/desktop_window_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_js/flutter_js_plugin.h>
@@ -16,26 +16,34 @@
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) bitsdojo_window_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "BitsdojoWindowPlugin");
-  bitsdojo_window_plugin_register_with_registrar(bitsdojo_window_linux_registrar);
-  g_autoptr(FlPluginRegistrar) desktop_window_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWindowPlugin");
+  g_autoptr(FlPluginRegistrar)
+  bitsdojo_window_linux_v3_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "BitsdojoWindowPlugin");
+  bitsdojo_window_plugin_register_with_registrar(bitsdojo_window_linux_v3_registrar);
+  g_autoptr(FlPluginRegistrar)
+  desktop_window_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWindowPlugin");
   desktop_window_plugin_register_with_registrar(desktop_window_registrar);
-  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  g_autoptr(FlPluginRegistrar)
+  file_selector_linux_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
-  g_autoptr(FlPluginRegistrar) flutter_js_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterJsPlugin");
+  g_autoptr(FlPluginRegistrar)
+  flutter_js_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterJsPlugin");
   flutter_js_plugin_register_with_registrar(flutter_js_registrar);
-  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
-  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
-  g_autoptr(FlPluginRegistrar) platform_device_id_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PlatformDeviceIdLinuxPlugin");
+  g_autoptr(FlPluginRegistrar)
+  flutter_secure_storage_linux_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(
+          flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar)
+  platform_device_id_linux_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "PlatformDeviceIdLinuxPlugin");
   platform_device_id_linux_plugin_register_with_registrar(platform_device_id_linux_registrar);
-  g_autoptr(FlPluginRegistrar) system_tray_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "SystemTrayPlugin");
+  g_autoptr(FlPluginRegistrar)
+  system_tray_registrar =
+          fl_plugin_registry_get_registrar_for_plugin(registry, "SystemTrayPlugin");
   system_tray_plugin_register_with_registrar(system_tray_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,15 +3,15 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  bitsdojo_window_linux
-  desktop_window
-  file_selector_linux
-  flutter_js
-  flutter_secure_storage_linux
-  platform_device_id_linux
-  system_tray
-  url_launcher_linux
-)
+        bitsdojo_window_linux_v3
+        desktop_window
+        file_selector_linux
+        flutter_js
+        flutter_secure_storage_linux
+        platform_device_id_linux
+        system_tray
+        url_launcher_linux
+        )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
 )

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,6 +1,7 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
+#include <bitsdojo_window_linux_v3/bitsdojo_window_plugin.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -49,7 +50,8 @@ static void my_application_activate(GApplication *application) {
     gtk_window_set_title(window, "dan_xi");
   }
 
-  gtk_window_set_default_size(window, 1280, 720);
+    bitsdojo_window_from(window);
+    gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
 
   g_autoptr(FlDartProject)

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,13 @@
 import FlutterMacOS
 import Foundation
 
-import bitsdojo_window_macos
+import bitsdojo_window_macos_v3
 import desktop_window
 import device_info_plus
 import file_selector_macos
 import flutter_js
 import flutter_secure_storage_macos
+import gal
 import in_app_review
 import open_file
 import path_provider_foundation
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterJsPlugin.register(with: registry.registrar(forPlugin: "FlutterJsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,7 +1,12 @@
 import Cocoa
 import FlutterMacOS
+import bitsdojo_window_macos_v3
 
-class MainFlutterWindow: NSWindow {
+class MainFlutterWindow: BitsdojoWindow {
+  override func bitsdojo_window_configure() -> UInt {
+    return BDW_HIDE_ON_STARTUP
+  }
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
+      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.9"
+    version: "3.4.6"
   args:
     dependency: transitive
     description:
@@ -73,51 +73,47 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
-  bitsdojo_window:
-    dependency: "direct main"
-    description:
-      path: bitsdojo_window
-      ref: master
-      resolved-ref: "6595419747e0ccdbfee5158ed133b386cd641d0a"
-      url: "https://github.com/DartGit-dev/bitsdojo_window.git"
-    source: git
-    version: "0.2.0"
-  bitsdojo_window_linux:
+  bitsdojo_window_linux_v3:
     dependency: "direct overridden"
     description:
       path: bitsdojo_window_linux
       ref: master
-      resolved-ref: "6595419747e0ccdbfee5158ed133b386cd641d0a"
-      url: "https://github.com/DartGit-dev/bitsdojo_window.git"
+      resolved-ref: "60fbd2f43dac5ba6004a0cc631e6347ca72d0f64"
+      url: "https://github.com/w568w/bitsdojo_window.git"
     source: git
-    version: "0.2.0"
-  bitsdojo_window_macos:
-    dependency: "direct overridden"
+    version: "3.0.1"
+  bitsdojo_window_macos_v3:
+    dependency: transitive
     description:
-      path: bitsdojo_window_macos
-      ref: master
-      resolved-ref: "6595419747e0ccdbfee5158ed133b386cd641d0a"
-      url: "https://github.com/DartGit-dev/bitsdojo_window.git"
-    source: git
-    version: "0.2.0"
-  bitsdojo_window_platform_interface:
-    dependency: "direct overridden"
+      name: bitsdojo_window_macos_v3
+      sha256: "34d6b95a28f82b72933af656bc4152ad2cebacbbf90f047c9301a86a30ac2fde"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  bitsdojo_window_platform_interface_v3:
+    dependency: transitive
     description:
-      path: bitsdojo_window_platform_interface
-      ref: master
-      resolved-ref: "6595419747e0ccdbfee5158ed133b386cd641d0a"
-      url: "https://github.com/DartGit-dev/bitsdojo_window.git"
-    source: git
-    version: "0.2.0"
-  bitsdojo_window_windows:
-    dependency: "direct overridden"
+      name: bitsdojo_window_platform_interface_v3
+      sha256: "13c60bab4f4209700c5eb4bc0f4a648cc1abaa33a4c1c3c6fbb503ff5966e636"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  bitsdojo_window_v3:
+    dependency: "direct main"
     description:
-      path: bitsdojo_window_windows
-      ref: master
-      resolved-ref: "6595419747e0ccdbfee5158ed133b386cd641d0a"
-      url: "https://github.com/DartGit-dev/bitsdojo_window.git"
-    source: git
-    version: "0.2.0"
+      name: bitsdojo_window_v3
+      sha256: "96b9852769b2381646fcd50ad6307e6b61d960b265ac23ed762cda1a518ed213"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  bitsdojo_window_windows_v3:
+    dependency: transitive
+    description:
+      name: bitsdojo_window_windows_v3
+      sha256: "543663080ced14e35b9b068e8de8ff785dc285858fe34d19d648ac9c70d25809"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -154,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "6c4dd11d05d056e76320b828a1db0fc01ccd376922526f8e9d6c796a5adbac20"
+      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.4.1"
   build_runner:
     dependency: "direct dev"
     description:
@@ -170,10 +166,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "6d6ee4276b1c5f34f21fdf39425202712d2be82019983d52f351c94aafbc2c41"
+      sha256: c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.10"
+    version: "7.2.11"
   built_collection:
     dependency: transitive
     description:
@@ -186,34 +182,34 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "598a2a682e2a7a90f08ba39c0aaa9374c5112340f0a2e275f61b59389543d166"
+      sha256: "723b4021e903217dfc445ec4cf5b42e27975aece1fc4ebbc1ca6329c2d9fb54e"
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.1"
+    version: "8.7.0"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: fd3d0dc1d451f9a252b32d95d3f0c3c487bc41a75eba2e6097cb0b9c71491b15
+      sha256: f98972704692ba679db144261172a8e20feb145636c617af0eb4022132a6797f
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.3.0"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: bb2b8403b4ccdc60ef5f25c70dead1f3d32d24b9d6117cfc087f496b178594a7
+      sha256: "56aa42a7a01e3c9db8456d9f3f999931f1e05535b5a424271e9a38cabf066613"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: b8eb814ebfcb4dea049680f8c1ffb2df399e4d03bf7a352c775e26fa06e02fa0
+      sha256: "759b9a9f8f6ccbb66c185df805fac107f05730b1dab9c64626d1008cca532257"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
   characters:
     dependency: transitive
     description:
@@ -250,10 +246,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      sha256: "1be9be30396d7e4c0db42c35ea6ccd7cc6a1e19916b5dc64d6ac216b5544d677"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.7.0"
   collection:
     dependency: "direct main"
     description:
@@ -282,10 +278,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
+      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+4"
+    version: "0.3.3+6"
   crypto:
     dependency: transitive
     description:
@@ -306,10 +302,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   dart_style:
     dependency: transitive
     description:
@@ -354,10 +350,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "2c35b6d1682b028e42d07b3aee4b98fa62996c10bc12cb651ec856a80d6a761b"
+      sha256: "7035152271ff67b072a211152846e9f1259cf1be41e34cd3e0b5463d2d6b8419"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.2"
+    version: "9.1.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -402,10 +398,10 @@ packages:
     dependency: "direct main"
     description:
       name: encrypt_shared_preferences
-      sha256: d81a9147c8584a37046c51d56132ff9a55de27c94fee70b9213ac8a94048f322
+      sha256: "3cf7064c1bc82ccfa42ccd71a37c72fab5f2c55085e5f4dc37316bc902fb7142"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5"
+    version: "0.4.6"
   event_bus:
     dependency: "direct main"
     description:
@@ -426,58 +422,58 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.0"
   file_picker:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "21145c9c268d54b1f771d8380c195d2d6f655e0567dc1ca2f9c134c02c819e0a"
+      sha256: "903dd4ba13eae7cef64acc480e91bf54c3ddd23b5b90b639c170f3911e489620"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.3"
+    version: "6.0.0"
   file_selector_linux:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "770eb1ab057b5ae4326d1c24cc57710758b9a46026349d021d6311bd27580046"
+      sha256: "045d372bf19b02aeb69cacf8b4009555fb5f6f0b7ad8016e5f46dd1387ddd492"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.2"
+    version: "0.9.2+1"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "4ada532862917bf16e3adb3891fe3a5917a58bae03293e497082203a80909412"
+      sha256: b15c3da8bd4908b9918111fa486903f5808e388b8d1c559949f584725a6594d6
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+1"
+    version: "0.9.3+3"
   file_selector_platform_interface:
     dependency: transitive
     description:
       name: file_selector_platform_interface
-      sha256: "412705a646a0ae90f33f37acfae6a0f7cbc02222d6cd34e479421c3e74d3853c"
+      sha256: "0aa47a725c346825a2bd396343ce63ac00bda6eff2fbc43eabe99737dede8262"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.6.1"
   file_selector_windows:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "1372760c6b389842b77156203308940558a2817360154084368608413835fc26"
+      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3"
+    version: "0.9.3+1"
   fixnum:
     dependency: transitive
     description:
@@ -507,14 +503,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_blurhash:
-    dependency: transitive
-    description:
-      name: flutter_blurhash
-      sha256: "05001537bd3fac7644fa6558b09ec8c0a3f2eba78c0765f88912882b1331a5c6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.0"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -527,10 +515,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_email_sender
-      sha256: "52b713a67a966be4d9e6f68a323fc0a5bc2da71c567eb451af1aa90d30adbc3a"
+      sha256: "5001e9158f91a8799140fb30a11ad89cd587244f30b4f848d87085985c49b60f"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.2"
   flutter_fgbg:
     dependency: "direct main"
     description:
@@ -543,18 +531,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      sha256: f73505c792cf083d5566e1a94002311be497d984b5607f25be36d685cf6361cf
+      sha256: d198297060d116b94048301ee6749cd2e7d03c1f2689783f52d210a6b7aba350
       url: "https://pub.dev"
     source: hosted
-    version: "5.7.2+3"
+    version: "5.8.0"
   flutter_js:
     dependency: "direct main"
     description:
       name: flutter_js
-      sha256: c4e0ff2cac3378e34eb0cafb58089377a7722d3531cdf9fcd5a53b5afc66c2dc
+      sha256: "5bf5db354fe78fe24cb90a5fa6b4423d38712440c88e3445c3dc88bc134c452f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.8.0"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
@@ -607,10 +595,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_layout_grid
-      sha256: "3c03d28f884d816d6f483bdd64dd79663abfb00eea7cb27ffe98380e8357af95"
+      sha256: "3529b7aa7ed2cb9861a0bbaa5c14d4be2beaf5a070ce0176077159f80c5de094"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   flutter_linkify:
     dependency: "direct main"
     description:
@@ -623,10 +611,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "2118df84ef0c3ca93f96123a616ae8540879991b8b57af2f81b76a7ada49b2a4"
+      sha256: ad76540d21c066228ee3f9d1dad64a9f7e46530e8bb7c85011a88bc1fd874bc5
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -669,10 +657,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "950e77c2bbe1692bc0874fc7fb491b96a4dc340457f4ea1641443d0a6c1ea360"
+      sha256: b068ffc46f82a55844acfa4fdbb61fad72fa2aef0905548419d97f0f95c456da
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.0.17"
   flutter_progress_dialog:
     dependency: "direct main"
     description:
@@ -686,10 +674,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "22dbf16f23a4bcf9d35e51be1c84ad5bb6f627750565edd70dab70f3ff5fff8f"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -726,18 +714,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "38f9501c7cb6f38961ef0e1eacacee2b2d4715c63cc83fe56449c4d3d0b47255"
+      sha256: "5809c66f9dd3b4b93b0a6e2e8561539405322ee767ac2f64d084e2ab5429d108"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   flutter_svg:
     dependency: transitive
     description:
       name: flutter_svg
-      sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"
+      sha256: bfc7cc3c75fe1282e8ce2e056d8fd1533f1a6848b65c379b4a5e7a9b623d3371
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   flutter_swiper_view:
     dependency: "direct main"
     description:
@@ -755,10 +743,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_typeahead
-      sha256: a3539f7a90246b152f569029dedcf0b842532d3f2a440701b520e0bf2acbcf42
+      sha256: b9942bd5b7611a6ec3f0730c477146cffa4cd4b051077983ba67ddfc9e7ee818
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.2"
+    version: "4.8.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -769,7 +757,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: c91a2268539cebe4d16533c2eafa39abd0483998
+      resolved-ref: f4e7b4e1afc8c760eb5bac80f6a2e299906d83ca
       url: "https://github.com/ponnamkarthik/FlutterToast.git"
     source: git
     version: "8.2.2"
@@ -781,14 +769,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
-  gallery_saver:
+  gal:
     dependency: "direct main"
     description:
-      name: gallery_saver
-      sha256: df8b7e207ca12d64c71e0710a7ee3bc48aa7206d51cc720716fedb1543a66712
+      name: gal
+      sha256: ebc581bea458be47e8e80761c4449ad3a0f045db206f6f4648885ac474444246
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
@@ -817,10 +805,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -850,82 +838,82 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "6296e98782726d37f59663f0727d0e978eee1ced1ffed45ccaba591786a7f7b3"
+      sha256: "7d7f2768df2a8b0a3cefa5ef4f84636121987d403130e70b17ef7e2cf650ba84"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.4"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8179b54039b50eee561676232304f487602e2950ffb3e8995ed9034d6505ca34"
+      sha256: d6a6e78821086b0b737009b09363018309bbc6de3fd88cc5c26bc2bb44a4957f
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.7+4"
+    version: "0.8.8+2"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "869fe8a64771b7afbc99fc433a5f7be2fea4d1cb3d7c11a48b6b579eb9c797f0"
+      sha256: "50bc9ae6a77eea3a8b11af5eb6c661eeb858fdd2f734c2a4fd17086922347ef7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: b3e2f21feb28b24dd73a35d7ad6e83f568337c70afab5eabac876e23803f264b
+      sha256: c5538cacefacac733c724be7484377923b476216ad1ead35a0d2eadcdc0fc497
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.8"
+    version: "0.8.8+2"
   image_picker_linux:
     dependency: transitive
     description:
       name: image_picker_linux
-      sha256: "02cbc21fe1706b97942b575966e5fbbeaac535e76deef70d3a242e4afb857831"
+      sha256: "4ed1d9bb36f7cd60aa6e6cd479779cc56a4cb4e4de8f49d487b1aaad831300fa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.1+1"
   image_picker_macos:
     dependency: transitive
     description:
       name: image_picker_macos
-      sha256: cee2aa86c56780c13af2c77b5f2f72973464db204569e1ba2dd744459a065af4
+      sha256: "3f5ad1e8112a9a6111c46d0b57a7be2286a9a07fc6e1976fdf5be2bd31d4ff62"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.1+1"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: c1134543ae2187e85299996d21c526b2f403854994026d575ae4cf30d7bb2a32
+      sha256: ed9b00e63977c93b0d2d2b343685bed9c324534ba5abafbb3dfbd6a780b1b514
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.9.1"
   image_picker_windows:
     dependency: transitive
     description:
       name: image_picker_windows
-      sha256: c3066601ea42113922232c7b7b3330a2d86f029f685bba99d82c30e799914952
+      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.1+1"
   in_app_review:
     dependency: "direct main"
     description:
       name: in_app_review
-      sha256: "16328b8202d36522322b95804ae5d975577aa9f584d634985849ba1099645850"
+      sha256: "41ec6f30427ab09eb6ae1c85c4a2a624a145fc5d726f023de4d97170ec9e5466"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.8"
   in_app_review_platform_interface:
     dependency: transitive
     description:
       name: in_app_review_platform_interface
-      sha256: b12ec9aaf6b34d3a72aa95895eb252b381896246bdad4ef378d444affe8410ef
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   intl:
     dependency: "direct overridden"
     description:
@@ -938,10 +926,10 @@ packages:
     dependency: "direct dev"
     description:
       name: intl_utils
-      sha256: "0d38f605f292321c0729f8c0632b845be77aa12d272b7bc5e3022bb670a7309e"
+      sha256: "5cad11e11ff7662c3cd0ef04729248591d71ed023d4ef0903a137528b4568adf"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.4"
+    version: "2.8.5"
   io:
     dependency: transitive
     description:
@@ -995,10 +983,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   logging:
     dependency: transitive
     description:
@@ -1067,10 +1055,10 @@ packages:
     dependency: "direct main"
     description:
       name: mutex
-      sha256: "03116a4e46282a671b46c12de649d72c0ed18188ffe12a8d0fc63e83f4ad88f4"
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   nanoid:
     dependency: transitive
     description:
@@ -1099,10 +1087,10 @@ packages:
     dependency: transitive
     description:
       name: octo_image
-      sha256: "107f3ed1330006a3bea63615e81cf637433f5135a52466c7caa0e7152bca9143"
+      sha256: "45b40f99622f11901238e18d48f5f12ea36426d8eced9f4cbf58479c7aa2430d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.0"
   open_file:
     dependency: "direct main"
     description:
@@ -1148,66 +1136,66 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "3087813781ab814e4157b172f1a11c46be20179fcc9bea043e0fba36bc0acaa2"
+      sha256: a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.15"
+    version: "2.1.1"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "2cec049d282c7f13c594b4a73976b0b4f2d7a1838a6dd5aaf7bd9719196bee86"
+      sha256: e595b98692943b4881b219f0a9e3945118d3c16bd7e2813f98ec6e532d905f72
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.27"
+    version: "2.2.1"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "916731ccbdce44d545414dd9961f26ba5fbaa74bcbb55237d8e65a623a8c7297"
+      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.4"
+    version: "2.3.1"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: ffbb8cc9ed2c9ec0e4b7a541e56fd79b138e8f47d2fb86815f15358a349b3b57
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.11"
+    version: "2.2.1"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "57585299a729335f1298b43245842678cb9f43a6310351b18fb577d6e33165ec"
+      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "1cb68ba4cd3a795033de62ba1b7b4564dace301f952de6bfb3cd91b202b6ee96"
+      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.7"
+    version: "2.2.1"
   permission_handler:
     dependency: "direct main"
     description:
       name: permission_handler
-      sha256: "63e5216aae014a72fe9579ccd027323395ce7a98271d9defa9d57320d001af81"
+      sha256: "284a66179cabdf942f838543e10413246f06424d960c92ba95c84439154fcac8"
       url: "https://pub.dev"
     source: hosted
-    version: "10.4.3"
+    version: "11.0.1"
   permission_handler_android:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "2ffaf52a21f64ac9b35fe7369bb9533edbd4f698e5604db8645b1064ff4cf221"
+      sha256: f9fddd3b46109bd69ff3f9efa5006d2d309b7aec0f3c1c5637a60a2d5659e76e
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.3"
+    version: "11.1.0"
   permission_handler_apple:
     dependency: transitive
     description:
@@ -1220,10 +1208,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: "7c6b1500385dd1d2ca61bb89e2488ca178e274a69144d26bbd65e33eae7c02a9"
+      sha256: "6760eb5ef34589224771010805bea6054ad28453906936f843a8cc4d3a55c4a4"
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.3"
+    version: "3.12.0"
   permission_handler_windows:
     dependency: transitive
     description:
@@ -1252,10 +1240,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "0a279f0707af40c890e80b1e9df8bb761694c074ba7e1d4ab1bc4b728e200b59"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
   platform_device_id:
     dependency: "direct main"
     description:
@@ -1308,18 +1296,18 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
+      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   pointer_interceptor:
     dependency: transitive
     description:
       name: pointer_interceptor
-      sha256: "6aa680b30d96dccef496933d00208ad25f07e047f644dc98ce03ec6141633a9a"
+      sha256: "7626e034489820fd599380d2bb4d3f4a0a5e3529370b62bfce53ab736b91adb2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+4"
+    version: "0.9.3+6"
   pointycastle:
     dependency: transitive
     description:
@@ -1388,34 +1376,34 @@ packages:
     dependency: "direct main"
     description:
       name: quick_actions
-      sha256: "0562d78b8d6a87576fb8fe55bc655bda6ebe3c61a5904df56d20bd88f98cf3a3"
+      sha256: "3930e1cf78a0574495b4ea741ee197323c4a9081321d6ae384b3bfcd84c7ea83"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.6"
   quick_actions_android:
     dependency: transitive
     description:
       name: quick_actions_android
-      sha256: e31ae2181d1bd3b07e375feda452ae573c90b65fee6d4ac64cf113c789bff8c3
+      sha256: df67c20583e05f5038a24c47bfa1b7b2977703ec2d162663017c5f9ef8707699
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.9"
   quick_actions_ios:
     dependency: transitive
     description:
       name: quick_actions_ios
-      sha256: "9ed8b003a65034de9f36a7f593026bf114c8796a38011b23240f8bf7e4668e2b"
+      sha256: "5a13ed27b6254184fdd4294e100e3172fa6ebfd8bea03e414634a0f760d49997"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   quick_actions_platform_interface:
     dependency: transitive
     description:
       name: quick_actions_platform_interface
-      sha256: "2985e12b5fecb5715a35cc0a3b2127b4391e1969e62bd0a4a721b4de21d5fedb"
+      sha256: d2a8566b56eec49f93934528b62033906199c60f4ffaef0cba9ef02fcfed8a81
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   quiver:
     dependency: transitive
     description:
@@ -1445,10 +1433,10 @@ packages:
     dependency: "direct main"
     description:
       name: screen_brightness
-      sha256: "62fd61a64e68b32b98b840bad7d8b6822bbc40e63c2b569a5f85528484c86b41"
+      sha256: ed8da4a4511e79422fc1aa88138e920e4008cd312b72cdaa15ccb426c0faaedd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.2+1"
   screen_brightness_android:
     dependency: transitive
     description:
@@ -1485,10 +1473,10 @@ packages:
     dependency: transitive
     description:
       name: screen_brightness_windows
-      sha256: "80d90ecdc63fc0823f2ecb1be323471619287937e14210650d7b25ca181abd05"
+      sha256: "9261bf33d0fc2707d8cf16339ce25768100a65e70af0fcabaf032fc12408ba86"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.3"
   screen_capture_event:
     dependency: "direct main"
     description:
@@ -1501,74 +1489,74 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: ed3fcea4f789ed95913328e629c0c53e69e80e08b6c24542f1b3576046c614e8
+      sha256: f74fc3f1cbd99f39760182e176802f693fa0ec9625c045561cfad54681ea93dd
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "7.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "0c6e61471bd71b04a138b8b588fa388e66d8b005e6f2deda63371c5c505a0981"
+      sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.1"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: "0344316c947ffeb3a529eac929e1978fcd37c26be4e8468628bac399365a3ca1"
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: fe8401ec5b6dcd739a0fe9588802069e608c3fdbfd3c3c93e546cf2f90438076
+      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: f39696b83e844923b642ce9dd4bd31736c17e697f6731a5adf445b1274cf3cd4
+      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.4"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: "71d6806d1449b0a9d4e85e0c7a917771e672a3d5dc61149cc9fac871115018e1"
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "23b052f17a25b90ff2b61aad4cc962154da76fb62848a9ce088efe30d7c50ab1"
+      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7347b194fb0bbeb4058e6a4e87ee70350b6b2b90f8ac5f8bd5b3a01548f6d33a"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: f95e6a43162bce43c9c3405f3eb6f39e5b5d11f65fab19196cf8225e2777624d
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.2"
   shelf:
     dependency: transitive
     description:
@@ -1731,10 +1719,10 @@ packages:
     dependency: "direct main"
     description:
       name: tutorial_coach_mark
-      sha256: ba60583d1b500111bf5040eb24330862b25162d926f72923b8e45c16621878b0
+      sha256: "1f1fd234790afb929dec7391a4d90aa54ffe8c8e4d278d9283df8e3f5ac5d63e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.9"
+    version: "1.2.11"
   typed_data:
     dependency: transitive
     description:
@@ -1771,66 +1759,66 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "781bd58a1eb16069412365c98597726cd8810ae27435f04b3b4d3a470bacd61e"
+      sha256: b1c9e98774adf8820c96fbc7ae3601231d324a7d5ebd8babe27b6dfac91357ba
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.12"
+    version: "6.2.1"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "78cb6dea3e93148615109e58e42c35d1ffbf5ef66c44add673d0ab75f12ff3af"
+      sha256: "31222ffb0063171b526d3e569079cf1f8b294075ba323443fdc690842bfd4def"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.37"
+    version: "6.2.0"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "9af7ea73259886b92199f9e42c116072f05ff9bea2dcb339ab935dfc957392c2"
+      sha256: "4ac97281cf60e2e8c5cc703b2b28528f9b50c8f7cebc71df6bdf0845f647268a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "6.2.0"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "207f4ddda99b95b4d4868320a352d374b0b7e05eefad95a4a26f57da413443f5"
+      sha256: "9f2d390e096fdbe1e6e6256f97851e51afc2d9c423d3432f1d6a02a8a9a8b9fd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.1.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "1c4fdc0bfea61a70792ce97157e5cc17260f61abbe4f39354513f39ec6fd73b1"
+      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.1.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: bfdfa402f1f3298637d71ca8ecfe840b4696698213d5346e9d12d4ab647ee2ea
+      sha256: "980e8d9af422f477be6948bdfb68df8433be71f5743a188968b0c1b887807e50"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: cc26720eefe98c1b71d85f9dc7ef0cada5132617046369d9dc296b3ecaa5cbb4
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.2.0"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "7967065dd2b5fccc18c653b97958fdf839c5478c28e767c61ee879f4e7882422"
+      sha256: "7754a1ad30ee896b265f8d14078b0513a4dba28d358eabb9d5f339886f4a1adc"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.7"
+    version: "3.1.0"
   uuid:
     dependency: "direct main"
     description:
@@ -1843,26 +1831,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: "670f6e07aca990b4a2bcdc08a784193c4ccdd1932620244c3a86bb72a0eac67f"
+      sha256: "0f0c746dd2d6254a0057218ff980fc7f5670fd0fcf5e4db38a490d31eed4ad43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9+1"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: "7451721781d967db9933b63f5733b1c4533022c0ba373a01bdd79d1a5457f69f"
+      sha256: "0edf6d630d1bfd5589114138ed8fada3234deacc37966bec033d3047c29248b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9+1"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "80a13c613c8bde758b1464a1755a7b3a8f2b6cec61fbf0f5a53c94c30f03ba2e"
+      sha256: d24333727332d9bd20990f1483af4e09abdb9b1fc7c3db940b56ab5c42790c26
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.9+1"
   vector_math:
     dependency: transitive
     description:
@@ -1899,26 +1887,26 @@ packages:
     dependency: "direct main"
     description:
       name: win32
-      sha256: f2add6fa510d3ae152903412227bda57d0d5a8da61d2c39c1fb022c9429a41c0
+      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.6"
+    version: "5.0.9"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: e4506d60b7244251bc59df15656a3093501c37fb5af02105a944d73eb95be4c9
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: e0b1147eec179d3911f1f19b59206448f78195ca1d20514134e10641b7d7fbff
+      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   xiao_mi_push_plugin:
     dependency: "direct main"
     description:
@@ -1945,5 +1933,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.10.0"
+  dart: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   url_launcher: ^6.1.12
   uni_links: ^0.5.1
   desktop_window: ^0.4.0
-  http: ^0.13.4
+  http: ^1.0.0
   dio: ^4.0.6
   shared_preferences: ^2.0.15
   flutter_phoenix: ^1.0.0
@@ -49,7 +49,7 @@ dependencies:
   image_picker: ^1.0.0
   clipboard: ^0.1.3
   flutter_inappwebview: ^5.3.2
-  permission_handler: ^10.2.0
+  permission_handler: ^11.0.1
   in_app_review: ^2.0.4
   flutter_linkify: ^6.0.0
   linkify: ^4.0.0
@@ -59,7 +59,7 @@ dependencies:
   dio_log: ^2.0.2
   json_serializable: ^6.2.0
   photo_view: ^0.14.0
-  gallery_saver: ^2.3.2
+  gal: ^2.1.2
   flutter_markdown:
     git:
       url: https://github.com/singularity-s0/flutter_markdown_selectable.git
@@ -68,19 +68,15 @@ dependencies:
     git:
       url: https://github.com/antler119/system_tray.git
       ref: main
-  bitsdojo_window:
-    git:
-      url: https://github.com/DartGit-dev/bitsdojo_window.git
-      path: bitsdojo_window
-      ref: master
+  bitsdojo_window_v3: ^3.0.0
   win32: ^5.0.2
-  file_picker: ^5.3.2
+  file_picker: ^6.0.0
   cached_network_image: ^3.2.1
-  flutter_typeahead: ^4.3.3
+  flutter_typeahead: ^4.8.0
   collection: '>=1.15.0 <2.0.0'
   meta: '>=1.3.0 <2.0.0'
   flutter_layout_grid: ^2.0.1
-  flutter_js: ^0.7.0
+  flutter_js: ^0.8.0
   flutter_math_fork: ^0.7.1
   platform_device_id: ^1.0.1
   uuid: ^3.0.6
@@ -99,10 +95,10 @@ dependencies:
   receive_intent:
     git:
       url: https://github.com/w568w/receive_intent.git
-  flutter_secure_storage: ^8.0.0
-  encrypt_shared_preferences: ^0.3.5
+  flutter_secure_storage: ^9.0.0
+  encrypt_shared_preferences: ^0.4.6
   device_identity: ^1.0.0
-  tutorial_coach_mark: ^1.2.9    
+  tutorial_coach_mark: ^1.2.9
 
 
 dependency_overrides:
@@ -115,34 +111,22 @@ dependency_overrides:
     git:
       url: https://github.com/singularity-s0/linkify.git
       ref: master
-  bitsdojo_window_platform_interface:
+
+  # Temporary fixed version of bitsdojo_window_linux_v3.
+  # Should be removed if the fix is merged in the upstream.
+  bitsdojo_window_linux_v3:
     git:
-      url: https://github.com/DartGit-dev/bitsdojo_window.git
-      path: bitsdojo_window_platform_interface
-      ref: master
-  bitsdojo_window_windows:
-    git:
-      url: https://github.com/DartGit-dev/bitsdojo_window.git
-      path: bitsdojo_window_windows
-      ref: master
-  bitsdojo_window_macos:
-    git:
-      url: https://github.com/DartGit-dev/bitsdojo_window.git
-      path: bitsdojo_window_macos
-      ref: master
-  bitsdojo_window_linux:
-    git:
-      url: https://github.com/DartGit-dev/bitsdojo_window.git
+      url: https://github.com/w568w/bitsdojo_window.git
       path: bitsdojo_window_linux
       ref: master
 
 dev_dependencies:
   build_runner: ^2.1.2
-  pubspec_generator: ^3.0.1
+  pubspec_generator: ^3.0.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
-  intl_utils: ^2.8.3
+  flutter_lints: ^3.0.0
+  intl_utils: ^2.8.5
 
 flutter_intl:
   enabled: true

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
+#include <bitsdojo_window_windows_v3/bitsdojo_window_plugin.h>
 #include <desktop_window/desktop_window_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_js/flutter_js_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <gal/gal_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <platform_device_id_windows/platform_device_id_windows_plugin.h>
 #include <screen_brightness_windows/screen_brightness_windows_plugin.h>
@@ -19,26 +20,28 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  BitsdojoWindowPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
-  DesktopWindowPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("DesktopWindowPlugin"));
-  FileSelectorWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FileSelectorWindows"));
-  FlutterJsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterJsPlugin"));
-  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
-  PermissionHandlerWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
-  PlatformDeviceIdWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PlatformDeviceIdWindowsPlugin"));
-  ScreenBrightnessWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
-  SharePlusWindowsPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
-  SystemTrayPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SystemTrayPlugin"));
-  UrlLauncherWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+    BitsdojoWindowPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
+    DesktopWindowPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("DesktopWindowPlugin"));
+    FileSelectorWindowsRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("FileSelectorWindows"));
+    FlutterJsPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("FlutterJsPlugin"));
+    FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+    GalPluginCApiRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("GalPluginCApi"));
+    PermissionHandlerWindowsPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+    PlatformDeviceIdWindowsPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("PlatformDeviceIdWindowsPlugin"));
+    ScreenBrightnessWindowsPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("ScreenBrightnessWindowsPlugin"));
+    SharePlusWindowsPluginCApiRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+    SystemTrayPluginRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("SystemTrayPlugin"));
+    UrlLauncherWindowsRegisterWithRegistrar(
+            registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,18 +3,19 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  bitsdojo_window_windows
-  desktop_window
-  file_selector_windows
-  flutter_js
-  flutter_secure_storage_windows
-  permission_handler_windows
-  platform_device_id_windows
-  screen_brightness_windows
-  share_plus
-  system_tray
-  url_launcher_windows
-)
+        bitsdojo_window_windows_v3
+        desktop_window
+        file_selector_windows
+        flutter_js
+        flutter_secure_storage_windows
+        gal
+        permission_handler_windows
+        platform_device_id_windows
+        screen_brightness_windows
+        share_plus
+        system_tray
+        url_launcher_windows
+        )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
 )

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -5,7 +5,7 @@
 #include "flutter_window.h"
 #include "run_loop.h"
 #include "utils.h"
-#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
+#include <bitsdojo_window_windows_v3/bitsdojo_window_plugin.h>
 auto bdw = bitsdojo_window_configure(BDW_HIDE_ON_STARTUP);
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,


### PR DESCRIPTION
This PR fixes #226 and upgrade dependencies.

I also applied `dart fix` to adapt to the recently introduced `super.xxx` grammar.

**Since I have changed some key dependencies and NOT walked through a thorough test, please check**:

- Whether saving to gallery still works on mobile platforms (i.e. Android, iOS)
- Whether the storage location (or keys?) of shared preferences have changed (there is a way to check this: upgrade from previous build, finding that all settings and accounts are lost, then the shared preferences should be read from different location and the answer is YES)