### PR TITLE
change: repick icon for adding course review

### DIFF
--- a/lib/common/pubspec.yaml.g.dart
+++ b/lib/common/pubspec.yaml.g.dart
@@ -58,7 +58,7 @@ const List<String> pre = <String>[];
 const List<String> build = <String>[r'338'];
 
 /// Build date in Unix Time (in seconds)
-const int timestamp = 1700069432;
+const int timestamp = 1702558207;
 
 /// Name [name]
 const String name = r'dan_xi';

--- a/lib/page/danke/course_group_detail.dart
+++ b/lib/page/danke/course_group_detail.dart
@@ -211,8 +211,8 @@ class CourseGroupDetailState extends State<CourseGroupDetail> {
             PlatformIconButton(
               padding: EdgeInsets.zero,
               icon: PlatformX.isMaterial(context)
-                  ? const Icon(Icons.reply)
-                  : const Icon(CupertinoIcons.arrowshape_turn_up_left),
+                  ? const Icon(Icons.add)
+                  : const Icon(CupertinoIcons.add),
               onPressed: () async {
                 if (await CourseReviewEditor.createNewPost(
                     context, _courseGroup!)) {


### PR DESCRIPTION
Change the icon for adding course review to `add` in favor of the feedback from the user group chat. 