### PR TITLE
fix: show grade for 初选免听/重修免听 courses

### DIFF
--- a/lib/page/dashboard/exam_detail.dart
+++ b/lib/page/dashboard/exam_detail.dart
@@ -454,7 +454,7 @@ class ExamListState extends State<ExamList> {
                                   child: Text(
                                       _cachedScoreData!
                                           .firstWhere((element) =>
-                                              element.name == value.name)
+                                              element.id == value.id)
                                           .level,
                                       textScaleFactor: 1.2),
                                 ));


### PR DESCRIPTION
Grade not shown caused by inconsistency of name between two data sources.
Matching course ID may be a better approach.

<img width="217" alt="image" src="https://github.com/DanXi-Dev/DanXi/assets/60533182/4ffeb3be-3291-45bb-8c3c-208b184d5c59">
