### PR TITLE
fix: empty classroom not showing correctly

### DIFF
--- a/lib/repository/fdu/empty_classroom_repository.dart
+++ b/lib/repository/fdu/empty_classroom_repository.dart
@@ -66,7 +66,7 @@ class EmptyClassroomRepository extends BaseRepositoryWithDio {
       final html = response.data!.substring(start, end);
       final patternForSeats = RegExp(r'>(\d+)<');
       final patternForUsages =
-          RegExp(r'<td style="background-color[^"]*">(.*?)<\/td>');
+          RegExp(r'<td style="background-color.*?>(.*?)<\/td>');
       final match1 = patternForSeats.firstMatch(html);
       String? roomCapacity;
       if (match1 != null) {
@@ -74,15 +74,8 @@ class EmptyClassroomRepository extends BaseRepositoryWithDio {
       }
       RoomInfo info = RoomInfo(classroomName, date, roomCapacity);
       info.busy = [];
-      bool first = true;
       final match2 = patternForUsages.allMatches(html);
       for (final match in match2) {
-        // the first <td> is used for showing capacity, not course
-        // so we ignore it
-        if (first) {
-          first = false;
-          continue;
-        }
         final content = match.group(1);
         if (content == null || content.isEmpty) {
           info.busy!.add(false);


### PR DESCRIPTION
The website structure may be updated and there is no need to ignore first `<td>` now, since it will not be recognized by regex.