### PR TITLE
Show scores on exam_detail page

### DIFF
--- a/lib/page/dashboard/exam_detail.dart
+++ b/lib/page/dashboard/exam_detail.dart
@@ -383,7 +383,8 @@ class ExamListState extends State<ExamList> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Column(
+                Expanded(
+                    child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -400,15 +401,18 @@ class ExamListState extends State<ExamList> {
                         value.location.trim() != "" ||
                         value.time.trim() != "")
                       Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        mainAxisAlignment: MainAxisAlignment.start,
                         children: [
-                          Text(
-                            "${value.date} ${value.time}",
-                            textScaleFactor: 0.8,
-                          ),
-                          const SizedBox(
-                            width: 8,
-                          ),
+                          if (value.date != "" || value.time != "") ...[
+                            Text(
+                              "${value.date} ${value.time}",
+                              textScaleFactor: 0.8,
+                            ),
+                            const SizedBox(
+                              width: 8,
+                            ),
+                          ] else
+                            ...[],
                           Text(
                             "${value.location} ",
                             textScaleFactor: 0.8,
@@ -422,7 +426,7 @@ class ExamListState extends State<ExamList> {
                         style: TextStyle(color: Theme.of(context).hintColor),
                       ),
                   ],
-                ),
+                )),
                 if (!value.type.contains("补") && !value.type.contains("缓")) ...[
                   Align(
                     alignment: Alignment.centerLeft,
@@ -440,24 +444,40 @@ class ExamListState extends State<ExamList> {
                         if (snapshot.hasData) {
                           _cachedScoreData = snapshot.data;
                           try {
-                            return Container(
-                                height: 28,
-                                width: 28,
-                                decoration: BoxDecoration(
-                                  border: Border.all(
-                                    color: Colors.white,
-                                    width: 1,
-                                  ),
-                                  //borderRadius: BorderRadius.circular(16),
+                            return Row(
+                              children: [
+                                const SizedBox(
+                                  width: 8,
                                 ),
-                                child: Center(
-                                  child: Text(
-                                      _cachedScoreData!
-                                          .firstWhere((element) =>
-                                              element.id == value.id)
-                                          .level,
-                                      textScaleFactor: 1.2),
-                                ));
+                                Container(
+                                    height: 36,
+                                    width: 36,
+                                    decoration: BoxDecoration(
+                                      border: Border.all(
+                                        color: Colors.white,
+                                        width: 1,
+                                      ),
+                                    ),
+                                    child: Column(children: [
+                                      Center(
+                                        child: Text(
+                                          _cachedScoreData!
+                                              .firstWhere((element) =>
+                                                  element.id == value.id)
+                                              .level,
+                                        ),
+                                      ),
+                                      Center(
+                                        child: Text(
+                                            _cachedScoreData!
+                                                .firstWhere((element) =>
+                                                    element.id == value.id)
+                                                .score!,
+                                            textScaleFactor: 0.6),
+                                      ),
+                                    ]))
+                              ],
+                            );
                             // If we cannot find such an element, we will build an empty SizedBox.
                           } catch (_) {}
                         }

--- a/lib/repository/fdu/edu_service_repository.dart
+++ b/lib/repository/fdu/edu_service_repository.dart
@@ -245,19 +245,6 @@ class ExamScore {
   final String credit;
   final String level;
   final String? score;
-  static const MAP_LEVEL_SCORE = {
-    "A": "4.0",
-    "A-": "3.7",
-    "B+": "3.3",
-    "B": "3.0",
-    "B-": "2.7",
-    "C+": "2.3",
-    "C": "2.0",
-    "C-": "1.7",
-    "D+": "1.3",
-    "D": "1.0",
-    "F": "0",
-  };
 
   ExamScore(this.id, this.name, this.type, this.credit, this.level, this.score);
 
@@ -282,7 +269,7 @@ class ExamScore {
         '${elements[1].text.trim()} ${elements[2].text.trim()}',
         elements[4].text.trim(),
         elements[5].text.trim(),
-        MAP_LEVEL_SCORE[elements[5].text.trim()]);
+        null);
   }
 }
 


### PR DESCRIPTION
1. show scores on exam_detail page
2. fix overflow when course name is too long
3. remove level-to-score mapping

效果：
![7aa777843da967e586607b6997edb55](https://github.com/DanXi-Dev/DanXi/assets/60533182/03350db5-96d5-438a-8056-b06e024fbf58)
