### PR TITLE
add: scrolling for quiz option list

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -83,8 +83,10 @@ If you are building for `iOS/iPadOS`, you should also [install and configure](ht
 Run the command 
 
 ```
-dart run build_runner build --delete-conflicting-outputs
+flutter pub get
+flutter pub global activate intl_utils
 dart run intl_utils:generate
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 and then  `flutter run [ios/android]` to start the app.

--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -570,7 +570,7 @@ class BBSPostDetailState extends State<BBSPostDetail> {
         PlatformContextMenuItem(
           onPressed: () async {
             bool? lock = await Noticing.showConfirmationDialog(
-                context, "锁定或解锁树洞？",
+                context, "锁定或解锁帖子？",
                 confirmText: "锁定", cancelText: "解锁");
             if (lock != null) {
               int? result = await ForumRepository.getInstance()
@@ -583,12 +583,12 @@ class BBSPostDetailState extends State<BBSPostDetail> {
           },
           isDestructive: true,
           menuContext: menuContext,
-          child: const Text("锁定/解锁树洞"),
+          child: const Text("锁定/解锁帖子"),
         ),
         PlatformContextMenuItem(
           onPressed: () async {
             bool? hide = await Noticing.showConfirmationDialog(
-                context, "隐藏或显示树洞？",
+                context, "隐藏或显示帖子？",
                 confirmText: "Hide", cancelText: "Unhide");
             if (hide != null) {
               int? result = hide
@@ -604,12 +604,12 @@ class BBSPostDetailState extends State<BBSPostDetail> {
           },
           isDestructive: true,
           menuContext: menuContext,
-          child: const Text("隐藏/显示树洞"),
+          child: const Text("隐藏/显示帖子"),
         ),
         PlatformContextMenuItem(
           onPressed: () async {
             bool? sens = await Noticing.showConfirmationDialog(
-                context, "标记或取消树洞敏感状态？",
+                context, "标记或取消帖子敏感状态？",
                 confirmText: "标记敏感", cancelText: "取消敏感");
             if (sens != null) {
               int? result = await ForumRepository.getInstance()

--- a/lib/page/forum/quiz.dart
+++ b/lib/page/forum/quiz.dart
@@ -293,6 +293,8 @@ class QuestionWidget extends StatefulWidget {
 }
 
 class QuestionWidgetState extends State<QuestionWidget> {
+  ScrollController optionsScrollController = ScrollController();
+
   List<bool> selectionState = [];
   bool multiSelect = false;
   static const labelChars = "ABCDEFGH";
@@ -349,29 +351,33 @@ class QuestionWidgetState extends State<QuestionWidget> {
                           text: widget.question.question!, style: largerText),
                     ],
                   )),
-                  Column(children: [
-                    ...Iterable<int>.generate(options.length)
-                        .map((index) => OptionWidget(
-                            active: selectionState[index],
-                            label: labelChars[index],
-                            content: options[index],
-                            tapCallback: () {
-                              setState(() {
-                                if (multiSelect) {
-                                  // Revert if multi-selection
-                                  selectionState[index] =
-                                      !selectionState[index];
-                                } else {
-                                  // We still have to set this to make the animation play
-                                  selectionState =
-                                      List.filled(options.length, false);
-                                  selectionState[index] = true;
-                                  // Submit answer and advance to next
-                                  widget.answerCallback(true, [options[index]]);
-                                }
-                              });
-                            }))
-                  ]),
+                  // Take up all remaining space in the middle
+                  Expanded(
+                      child: ListView.builder(
+                          addAutomaticKeepAlives: true,
+                          itemCount: options.length,
+                          controller: optionsScrollController,
+                          itemBuilder: (ctx, index) => OptionWidget(
+                              active: selectionState[index],
+                              label: labelChars[index],
+                              content: options[index],
+                              tapCallback: () {
+                                setState(() {
+                                  if (multiSelect) {
+                                    // Revert if multi-selection
+                                    selectionState[index] =
+                                        !selectionState[index];
+                                  } else {
+                                    // We still have to set this to make the animation play
+                                    selectionState =
+                                        List.filled(options.length, false);
+                                    selectionState[index] = true;
+                                    // Submit answer and advance to next
+                                    widget
+                                        .answerCallback(true, [options[index]]);
+                                  }
+                                });
+                              }))),
                   if (multiSelect)
                     Row(
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/lib/util/watermark.dart
+++ b/lib/util/watermark.dart
@@ -43,7 +43,7 @@ class Watermark {
                       SettingsProvider.getInstance().darkWatermarkColor)
                       : Color(SettingsProvider.getInstance()
                       .lightWatermarkColor),
-                  fontSize: 36,
+                  fontSize: 48,
                   decoration: TextDecoration.none),
         ));
 

--- a/lib/widget/libraries/paged_listview.dart
+++ b/lib/widget/libraries/paged_listview.dart
@@ -225,7 +225,8 @@ class PagedListViewState<T> extends State<PagedListView<T>>
           if (snapshot.error != null &&
               snapshot.error is FatalException &&
               widget.fatalErrorBuilder != null) {
-            _clearData();
+            // We cannot clear the error here
+            _clearData(clearError: false);
             pageIndex = widget.startPage;
             return widget.fatalErrorBuilder!.call(context, snapshot.error);
           } else {
@@ -396,11 +397,13 @@ class PagedListViewState<T> extends State<PagedListView<T>>
   }
 
   /// Clear all the data saved.
-  void _clearData() {
+  void _clearData({bool clearError = true}) {
     _data.clear();
     valueKeys.clear();
-    _hasError = false;
     _dataClearQueued = false;
+    if(clearError){
+      _hasError = true;
+    }
   }
 
   @override
@@ -448,7 +451,7 @@ class PagedListViewState<T> extends State<PagedListView<T>>
     });
   }
 
-  replaceDatumWith(T data, int index){
+  replaceDatumWith(T data, int index) {
     setState(() {
       _data[index] = data;
     });
@@ -477,7 +480,7 @@ class PagedListViewState<T> extends State<PagedListView<T>>
     }
   }
 
-  int _calculateRealWidgetCount(){
+  int _calculateRealWidgetCount() {
     return _data.length +
         (_isRefreshing ? 1 : 0) +
         (_isEnded ? 1 : 0) +

--- a/lib/widget/libraries/paged_listview.dart
+++ b/lib/widget/libraries/paged_listview.dart
@@ -397,6 +397,8 @@ class PagedListViewState<T> extends State<PagedListView<T>>
   }
 
   /// Clear all the data saved.
+  /// We don't want to clear the error if this function is called from an error handler, 
+  /// so we add separate control for whether to clear [_hasError]
   void _clearData({bool clearError = true}) {
     _data.clear();
     valueKeys.clear();

--- a/lib/widget/libraries/paged_listview.dart
+++ b/lib/widget/libraries/paged_listview.dart
@@ -402,7 +402,7 @@ class PagedListViewState<T> extends State<PagedListView<T>>
     valueKeys.clear();
     _dataClearQueued = false;
     if(clearError){
-      _hasError = true;
+      _hasError = false;
     }
   }
 


### PR DESCRIPTION
Fixes #408.  
Also fixed a long-existing bug in `PagedListView` that stuck me for over half an hour, demonstrated as followed:  

`_hasError` is set to `true` in `errorBuilder`, as we expect. 
<https://github.com/DanXi-Dev/DanXi/blob/c0037b9fb38b211e8649fc91de3d754855d9026b/lib/widget/libraries/paged_listview.dart#L223>
However, in the following lines, `_clearData` is called. 
<https://github.com/DanXi-Dev/DanXi/blob/c0037b9fb38b211e8649fc91de3d754855d9026b/lib/widget/libraries/paged_listview.dart#L228>
In which `_hasError` is restored back to `false`, overwriting the assignment on line 223. 
<https://github.com/DanXi-Dev/DanXi/blob/c0037b9fb38b211e8649fc91de3d754855d9026b/lib/widget/libraries/paged_listview.dart#L399-L404>
This causes `_hasError` to be `false` regardless of whether there is an error or not, which lead to unexpected behaviors when judging `_hasError` in `if` statements. 