### PR TITLE
Close #389

### DIFF
--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -59,6 +59,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:lazy_load_indexed_stack/lazy_load_indexed_stack.dart';
 import 'package:provider/provider.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:quick_actions/quick_actions.dart';
 import 'package:receive_intent/receive_intent.dart' as ri;
 import 'package:screen_capture_event/screen_capture_event.dart';
@@ -749,8 +750,7 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
     if (PlatformX.isIOS) return;
     final UpdateInfo updateInfo =
         AnnouncementRepository.getInstance().checkVersion();
-    if (updateInfo.isAfter(
-        Pubspec.version.major, Pubspec.version.minor, Pubspec.version.patch)) {
+    if (updateInfo.isAfter(Version.parse(Pubspec.version.canonical))) {
       await showPlatformDialog(
           context: context,
           builder: (BuildContext context) => PlatformAlertDialog(

--- a/lib/page/subpage_settings.dart
+++ b/lib/page/subpage_settings.dart
@@ -1053,7 +1053,7 @@ class SettingsSubpageState extends PlatformSubpageState<SettingsSubpage> {
                         alignment: Alignment.centerRight,
                         child: Text(
                           '${S.of(context).version} ${FlutterApp.versionName} build ${Pubspec.version.build.single} #${const String.fromEnvironment("GIT_HASH", defaultValue: "?")}',
-                          textScaleFactor: 0.7,
+                          textScaler: const TextScaler.linear(0.7),
                           style: const TextStyle(fontWeight: FontWeight.bold),
                         ),
                       ),

--- a/lib/repository/app/announcement_repository.dart
+++ b/lib/repository/app/announcement_repository.dart
@@ -23,6 +23,7 @@ import 'package:dan_xi/model/extra.dart';
 import 'package:dan_xi/util/io/dio_utils.dart';
 import 'package:dan_xi/util/shared_preferences.dart';
 import 'package:dio/dio.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:toml/toml.dart';
 
 class AnnouncementRepository {
@@ -147,23 +148,5 @@ class UpdateInfo {
 
   UpdateInfo(this.latestVersion, this.changeLog);
 
-  bool isAfter(int major, int minor, int patch) {
-    List<int?> versions =
-        latestVersion!.split(".").map((e) => int.tryParse(e)).toList();
-    if (versions[0]! > major) {
-      return true;
-    } else if (versions[0]! < major) {
-      return false;
-    }
-
-    if (versions[1]! > minor) {
-      return true;
-    } else if (versions[1]! < minor) {
-      return false;
-    }
-
-    if (versions[2]! > patch) return true;
-
-    return false;
-  }
+  bool isAfter(Version version) => Version.parse(latestVersion!) > version;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1568,7 +1568,7 @@ packages:
     source: hosted
     version: "6.1.2"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   cookie_jar: any
   ffi: any
   toml: ^0.16.0
+  pub_semver: ^2.1.4
 
 dependency_overrides:
   intl: ^0.19.0


### PR DESCRIPTION
This PR will:

1. close #389.

---

It's important to highlight that this PR does not alter how versions are rendered in the UI or User Agent. There are primarily two areas where the version concatenation is utilized:

1. The "About" section on the settings page. Since the commit hash is also shown here, this should not be considered a blocker for identifying the user's version.
2. The User Agent. While a canonical version string is not included, the current setup is only used to block outdated versions from accessing the forum. The remote server can still identify the version using the build code. In any case, we can always release a version with a higher build code to restore access to the server.
