### PR TITLE
Support syntax highlight for markdown and modify course review labels

### DIFF
--- a/lib/model/danke/course.dart
+++ b/lib/model/danke/course.dart
@@ -54,8 +54,14 @@ class Course {
   @JsonKey(name: 'review_list')
   List<CourseReview>? reviewList;
 
-  Course({this.id, this.teachers, this.maxStudent, this.year, this.semester,
-      this.credit, this.reviewList});
+  Course(
+      {this.id,
+      this.teachers,
+      this.maxStudent,
+      this.year,
+      this.semester,
+      this.credit,
+      this.reviewList});
 
   factory Course.fromJson(Map<String, dynamic> json) => _$CourseFromJson(json);
 
@@ -68,8 +74,16 @@ class Course {
   int get hashCode => id ?? id.hashCode;
 
   String formatTime() {
-    // Todo: add support for other semesters
-    return "$year学年-${semester == 1 ? "秋季" : "春季"}";
+    // Todo: add i18n
+    final semesterString = switch (semester ?? 0) {
+      1 => "秋季",
+      2 => "寒假",
+      3 => "春季",
+      4 => "暑假",
+      _ => "未知"
+    };
+    final yearString = year == null ? "未知" : "$year~${year! + 1}";
+    return "$yearString学年-$semesterString";
   }
 
   CourseSummary getSummary() {

--- a/lib/page/danke/course_review_editor.dart
+++ b/lib/page/danke/course_review_editor.dart
@@ -341,6 +341,9 @@ class CourseReviewEditorWidgetState extends State<CourseReviewEditorWidget> {
     final assessmentWord =
         S.of(context).curriculum_ratings_assessment_words.split(';');
 
+    // Reduce the line height to fit into the dropdown list
+    final listItemStyle = TextStyle(height: 1.0);
+
     return ChangeNotifierProvider(
         create: (_) => review.grade.clone(),
         child: SingleChildScrollView(
@@ -370,8 +373,7 @@ class CourseReviewEditorWidgetState extends State<CourseReviewEditorWidget> {
                             teacherFilterNotifier.value = e!;
                           },
                           itemBuilder: (e) => DropdownMenuItem(
-                              value: e,
-                              child: Text(e, overflow: TextOverflow.ellipsis)),
+                              value: e, child: Flexible(child: Text(e, style: listItemStyle,))),
                         )),
                     Expanded(
                         flex: 1,
@@ -391,8 +393,8 @@ class CourseReviewEditorWidgetState extends State<CourseReviewEditorWidget> {
                                   },
                                   itemBuilder: (e) => DropdownMenuItem(
                                       value: e,
-                                      child: Text(e.formatTime(),
-                                          overflow: TextOverflow.ellipsis))),
+                                      child: Flexible(
+                                          child: Text(e.formatTime(), style: listItemStyle,)))),
                           valueListenable: teacherFilterNotifier,
                         )),
                   ]),

--- a/lib/page/danke/course_review_editor.dart
+++ b/lib/page/danke/course_review_editor.dart
@@ -342,7 +342,7 @@ class CourseReviewEditorWidgetState extends State<CourseReviewEditorWidget> {
         S.of(context).curriculum_ratings_assessment_words.split(';');
 
     // Reduce the line height to fit into the dropdown list
-    final listItemStyle = TextStyle(height: 1.0);
+    final listItemStyle = const TextStyle(height: 1.0);
 
     return ChangeNotifierProvider(
         create: (_) => review.grade.clone(),

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -131,9 +131,7 @@ String renderText(String content, String imagePlaceholder,
 
   // If we have reduce the text to nothing, we would rather not remove mention texts.
   if (result.isEmpty && removeMentions) {
-    return renderText(originalContent,
-        imagePlaceholder,
-        formulaPlaceholder,
+    return renderText(originalContent, imagePlaceholder, formulaPlaceholder,
         stickerPlaceholder,
         removeMentions: false);
   } else {
@@ -360,15 +358,11 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
     if (!context.read<ForumProvider>().isUserInitialized) {
       await ForumRepository.getInstance().initializeRepo();
       context.read<ForumProvider>().currentDivisionId =
-          ForumRepository.getInstance()
-              .getDivisions()
-              .firstOrNull
-              ?.division_id;
+          ForumRepository.getInstance().getDivisions().firstOrNull?.division_id;
     }
 
     bool answered =
-        await ForumRepository.getInstance().hasAnsweredQuestions() ??
-            true;
+        await ForumRepository.getInstance().hasAnsweredQuestions() ?? true;
     if (!answered) {
       throw QuizUnansweredError(
           "User hasn't finished the quiz of forum rules yet. ");
@@ -448,8 +442,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
       } else if (_postsType == PostsType.SUBSCRIBED_DISCUSSION) {
         await ForumRepository.getInstance().getSubscribedHoleId();
       } else if (context.read<ForumProvider>().isUserInitialized) {
-        await ForumRepository.getInstance()
-            .loadDivisions(useCache: false);
+        await ForumRepository.getInstance().loadDivisions(useCache: false);
         await refreshSelf();
       }
     } finally {

--- a/lib/widget/danke/course_review_widget.dart
+++ b/lib/widget/danke/course_review_widget.dart
@@ -156,6 +156,7 @@ class ReviewHeader extends StatelessWidget {
             child: const Wrap(
               // todo this is the badge list of the user
               spacing: 3,
+              runSpacing: 2,
               alignment: WrapAlignment.end,
               children: [
                 // rating
@@ -183,7 +184,8 @@ class ReviewHeader extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 6),
         child: Wrap(
           // todo this is the badge list of the user
-          spacing: 4,
+          spacing: 3,
+          runSpacing: 2,
           alignment: WrapAlignment.start,
           children: [
             // rating

--- a/lib/widget/danke/course_widgets.dart
+++ b/lib/widget/danke/course_widgets.dart
@@ -214,7 +214,7 @@ class FilterListWidgetState<T> extends State<FilterListWidget<T>> {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(spacing: 4, runSpacing: 4, children: [
+    return Wrap(spacing: 3, runSpacing: 2, children: [
       ...widget.filters.map(
         (e) => FilterTagWidget(
             color: e.filter == selectedTag!.filter

--- a/lib/widget/forum/render/render_impl.dart
+++ b/lib/widget/forum/render/render_impl.dart
@@ -148,9 +148,7 @@ final kMarkdownRenderFactory = (double? defaultFontSize) =>
             MarkdownHoleMentionSupport.tag:
                 MarkdownHoleMentionSupport(translucentCard, isPreviewWidget),
           },
-          imageBuilder: imageBuilder,
-          extensionSet:
-              md.ExtensionSet([const md.FencedCodeBlockSyntax()], []));
+          imageBuilder: imageBuilder);
     };
 
 final BaseRender kMarkdownRender = kMarkdownRenderFactory(kFontSize);

--- a/lib/widget/forum/render/render_impl.dart
+++ b/lib/widget/forum/render/render_impl.dart
@@ -23,11 +23,12 @@ import 'package:dan_xi/widget/forum/auto_bbs_image.dart';
 import 'package:dan_xi/widget/forum/forum_widgets.dart';
 import 'package:dan_xi/widget/forum/render/base_render.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_highlighter/flutter_highlighter.dart';
-import 'package:flutter_highlighter/themes/atom-one-dark.dart';
-import 'package:flutter_highlighter/themes/atom-one-light.dart';
+import 'package:flutter_highlighting/flutter_highlighting.dart';
+import 'package:flutter_highlighting/themes/atom-one-dark.dart';
+import 'package:flutter_highlighting/themes/atom-one-light.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+import 'package:highlighting/languages/all.dart';
 import 'package:markdown/markdown.dart' as md;
 import 'package:nil/nil.dart';
 
@@ -190,35 +191,27 @@ final BaseRender kMarkdownSelectorRender = (BuildContext context,
 class HighlightBuilder extends MarkdownElementBuilder {
   static const String tag = "code";
   final Map<String, TextStyle>? theme;
+  final TextStyle? textStyle;
 
-  HighlightBuilder([this.theme]);
+  HighlightBuilder([this.theme, this.textStyle]);
 
   @override
   Widget visitElementAfter(md.Element element, TextStyle? preferredStyle) {
-    if (element.attributes['class'] == null &&
-        !element.textContent.trim().contains('\n')) {
-      return Container(
-          padding: const EdgeInsets.only(
-              top: 0.0, right: 4.0, bottom: 1.75, left: 4.0),
-          margin: const EdgeInsets.symmetric(horizontal: 2.0),
-          color: Colors.black12,
-          child: Text(element.textContent,
-              style:
-                  const TextStyle(fontFamily: 'RobotoMono', fontSize: 12.0)));
-    } else {
-      var language = 'plaintext';
-      final pattern = RegExp(r'^language-(.+)$');
-      if (element.attributes['class'] != null &&
-          pattern.hasMatch(element.attributes['class']!)) {
-        language = pattern.firstMatch(element.attributes['class']!)?.group(1) ??
-            'plaintext';
-      }
-      return HighlightView(element.textContent.trim(),
-          language: language,
-          theme: theme ?? {},
-          padding: const EdgeInsets.all(12),
-          textStyle: const TextStyle(fontFamily: 'RobotoMono', fontSize: 12));
+    var language = 'plaintext';
+    final pattern = RegExp(r'^language-(.+)$');
+    if (element.attributes['class'] != null &&
+        pattern.hasMatch(element.attributes['class']!)) {
+      language = pattern.firstMatch(element.attributes['class']!)?.group(1) ??
+          'plaintext';
     }
+    return HighlightView(element.textContent.trim(),
+        // Avoid null error if language doesn't exist
+        languageId:
+            builtinLanguages.containsKey(language) ? language : 'plaintext',
+        theme: theme ?? {},
+        padding: const EdgeInsets.all(8),
+        textStyle: textStyle ??
+            const TextStyle(fontFamily: 'Monospace', fontSize: 16.0));
   }
 }
 

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -36,10 +36,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-    g_autoptr(FlPluginRegistrar)
-    open_file_linux_registrar =
-            fl_plugin_registry_get_registrar_for_plugin(registry, "OpenFileLinuxPlugin");
-    open_file_linux_plugin_register_with_registrar(open_file_linux_registrar);
+  g_autoptr(FlPluginRegistrar) open_file_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "OpenFileLinuxPlugin");
+  open_file_linux_plugin_register_with_registrar(open_file_linux_registrar);
   g_autoptr(FlPluginRegistrar) platform_device_id_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "PlatformDeviceIdLinuxPlugin");
   platform_device_id_linux_plugin_register_with_registrar(platform_device_id_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -9,7 +9,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_js
   flutter_secure_storage_linux
   gtk
-        open_file_linux
+  open_file_linux
   platform_device_id_linux
   tray_manager
   url_launcher_linux

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "72.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.2"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.4.1"
   app_links:
     dependency: "direct main"
     description:
@@ -194,18 +189,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: dd09dd4e2b078992f42aac7f1a622f01882a8492fef08486b27ddde929c19f04
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.12"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.2"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -346,10 +341,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.6"
   desktop_window:
     dependency: "direct main"
     description:
@@ -954,10 +949,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: c0a6763d50b354793d0192afd0a12560b823147d3ded7c6b77daf658fa05cc85
+      sha256: "8c5abf0dcc24fe6e8e0b4a5c0b51a5cf30cefdf6407a3213dae61edc75a70f56"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+13"
+    version: "0.8.12+12"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1082,18 +1077,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1135,14 +1130,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2-main.4"
   markdown:
     dependency: "direct main"
     description:
@@ -1171,10 +1158,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   menu_base:
     dependency: transitive
     description:
@@ -1187,10 +1174,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1865,10 +1852,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "7b41b6c3507854a159e24ae90a8e3e9cc01eb26a477c118d6dca065b5f55453e"
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4+2"
+    version: "2.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -1921,10 +1908,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: a824e842b8a054f91a728b783c177c1e4731f6b124f9192468457a8913371255
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -1937,10 +1924,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   timezone:
     dependency: transitive
     description:
@@ -2017,10 +2004,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: e35a698ac302dd68e41f73250bd9517fe3ab5fa4f18fe4647a0872db61bacbab
+      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.10"
+    version: "6.3.9"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -2113,10 +2100,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -2199,5 +2186,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -441,6 +441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   event_bus:
     dependency: "direct main"
     description:
@@ -566,14 +574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
-  flutter_highlighter:
+  flutter_highlighting:
     dependency: "direct main"
     description:
-      name: flutter_highlighter
-      sha256: "93173afd47a9ada53f3176371755e7ea4a1065362763976d06d6adfb4d946e10"
+      name: flutter_highlighting
+      sha256: "426770b1453e8302f8cc58455ebcaad33e3049e73ca18f9d3c83554552bf3baf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.9.0+11.8.0"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -903,14 +911,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  highlighter:
-    dependency: transitive
+  highlighting:
+    dependency: "direct main"
     description:
-      name: highlighter
-      sha256: "92180c72b9da8758e1acf39a45aa305a97dcfe2fdc8f3d1d2947c23f2772bfbc"
+      name: highlighting
+      sha256: "196005ed9c98ee559939fcecd466fa941b9e99b3a93394691b86780ad4da50f3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.9.0+11.8.0"
   html:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -710,12 +710,11 @@ packages:
   flutter_markdown:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "0edfbd6ba76963b1c5952a6b19ca4264275a1be1"
-      url: "https://github.com/singularity-s0/flutter_markdown_selectable.git"
-    source: git
-    version: "0.6.13+1"
+      name: flutter_markdown
+      sha256: a23c41ee57573e62fc2190a1f36a0480c4d90bde3a8a8d7126e5d5992fb53fb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.3+1"
   flutter_math_fork:
     dependency: "direct main"
     description:
@@ -1077,18 +1076,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1134,10 +1133,10 @@ packages:
     dependency: "direct main"
     description:
       name: markdown
-      sha256: c2b81e184067b41d0264d514f7cdaa2c02d38511e39d6521a1ccc238f6d7b3f2
+      sha256: ef2a1298144e3f985cc736b22e0ccdaf188b5b3970648f2d9dc13efd1d9df051
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "7.2.2"
   matcher:
     dependency: transitive
     description:
@@ -1158,10 +1157,10 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   menu_base:
     dependency: transitive
     description:
@@ -1174,10 +1173,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1924,10 +1923,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timezone:
     dependency: transitive
     description:
@@ -2100,10 +2099,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "72.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.7.0"
   app_links:
     dependency: "direct main"
     description:
@@ -189,18 +194,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: dd09dd4e2b078992f42aac7f1a622f01882a8492fef08486b27ddde929c19f04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.12"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "7.3.2"
   built_collection:
     dependency: transitive
     description:
@@ -341,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.7"
   desktop_window:
     dependency: "direct main"
     description:
@@ -972,10 +977,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "8c5abf0dcc24fe6e8e0b4a5c0b51a5cf30cefdf6407a3213dae61edc75a70f56"
+      sha256: c0a6763d50b354793d0192afd0a12560b823147d3ded7c6b77daf658fa05cc85
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+12"
+    version: "0.8.12+13"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1153,6 +1158,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.7.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   markdown:
     dependency: "direct main"
     description:
@@ -1875,10 +1888,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      sha256: "4058172e418eb7e7f2058dcb7657d451a8fc264afa0dea4dbd0f304a57131611"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.4+3"
   stack_trace:
     dependency: transitive
     description:
@@ -1931,10 +1944,10 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      sha256: "51b08572b9f091f8c3eb4d9d4be253f196ff0075d5ec9b10a884026d5b55d7bc"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0+1"
+    version: "3.3.0+2"
   term_glyph:
     dependency: transitive
     description:
@@ -2027,10 +2040,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      sha256: e35a698ac302dd68e41f73250bd9517fe3ab5fa4f18fe4647a0872db61bacbab
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.9"
+    version: "6.3.10"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -2209,5 +2222,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -566,6 +566,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  flutter_highlighter:
+    dependency: "direct main"
+    description:
+      name: flutter_highlighter
+      sha256: "93173afd47a9ada53f3176371755e7ea4a1065362763976d06d6adfb4d946e10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   flutter_inappwebview:
     dependency: "direct main"
     description:
@@ -895,6 +903,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  highlighter:
+    dependency: transitive
+    description:
+      name: highlighter
+      sha256: "92180c72b9da8758e1acf39a45aa305a97dcfe2fdc8f3d1d2947c23f2772bfbc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   html:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,8 @@ dependencies:
   gal: ^2.1.2
   flutter_markdown: ^0.7.3
   markdown: ^7.2.2
-  flutter_highlighter: ^0.1.1
+  flutter_highlighting: ^0.9.0
+  highlighting: ^0.9.0
   tray_manager: ^0.2.1
   bitsdojo_window: ^0.1.6
   win32: ^5.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dependencies:
   gal: ^2.1.2
   flutter_markdown: ^0.7.3
   markdown: ^7.2.2
+  flutter_highlighter: ^0.1.1
   tray_manager: ^0.2.1
   bitsdojo_window: ^0.1.6
   win32: ^5.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
     git:
       url: https://github.com/singularity-s0/flutter_markdown_selectable.git
   markdown: ^6.0.0
+  markdown_widget: ^2.3.2
   tray_manager: ^0.2.1
   bitsdojo_window: ^0.1.6
   win32: ^5.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,11 +58,8 @@ dependencies:
   json_serializable: ^6.2.0
   photo_view: ^0.15.0
   gal: ^2.1.2
-  flutter_markdown:
-    git:
-      url: https://github.com/singularity-s0/flutter_markdown_selectable.git
-  markdown: ^6.0.0
-  markdown_widget: ^2.3.2
+  flutter_markdown: ^0.7.3
+  markdown: ^7.2.2
   tray_manager: ^0.2.1
   bitsdojo_window: ^0.1.6
   win32: ^5.0.2


### PR DESCRIPTION
Resolves #386, closes #309.  
Implementation of syntax highlight is powered by `flutter_highlighting`. 

> 原 issue 中提到的 [flutter_highlight](https://pub.dev/packages/flutter_highlight) 最后更新是 2021 年，其 fork 版 [flutter_highlighting](https://pub.dev/packages/flutter_highlighting) 也已经停止维护约 10 个月。我的建议是迁移到支持代码高亮的 Markdown 库，[markdown_widget](https://pub.dev/packages/markdown_widget)。

I didn't use [markdown_widget](https://pub.dev/packages/markdown_widget) because it supports less customization settings than [flutter_markdown](https://pub.dev/packages/flutter_markdown) and thus makes switching difficult. Moreover, [markdown_widget](https://pub.dev/packages/markdown_widget) depends on [flutter_highlight](https://pub.dev/packages/flutter_highlight) for syntax highlighting, which haven't been updated for 3 years (much longer than [flutter_highlighting](https://pub.dev/packages/flutter_highlighting)). 