### PR TITLE
Upgrade Gradle version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,7 +39,7 @@ gradle.taskGraph.whenReady {
 android {
     compileSdkVersion 34
 
-    ndkVersion "26.2.11394342"
+    ndkVersion "28.0.12433566"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -81,6 +81,5 @@ flutter {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:2.0.0"
     implementation 'com.google.android.material:material:1.12.0'
 }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.w568w.dan_xi">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.github.w568w.dan_xi">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Access to the Internet -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -38,7 +37,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:dataExtractionRules="@xml/data_extraction_rules">
         <activity
-            android:name=".MainActivity"
+            android:name="io.github.w568w.dan_xi.MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:exported="true"
             android:hardwareAccelerated="true"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,12 +7,30 @@ allprojects {
 
 rootProject.buildDir = '../build'
 
+
 subprojects {
     afterEvaluate { project ->
+        // override the android compileSdkVersion and namespace for each dependencies to compile with the latest Gradle
         if (project.plugins.hasPlugin("com.android.application") ||
                 project.plugins.hasPlugin("com.android.library")) {
-            project.android {
-                compileSdkVersion 34
+            project.android.compileSdkVersion = 34
+            if (project.android.namespace == null) {
+                def manifest = new XmlSlurper().parse(file(project.android.sourceSets.main.manifest.srcFile))
+                def packageName = manifest.@package.text()
+                println("Setting ${packageName} as android namespace")
+                project.android.namespace = packageName
+            }
+            // override the kotlin language version for each dependencies to 2.0.20
+            if (project.buildscript.configurations.hasProperty("classpath")) {
+                def found = false
+                project.buildscript.configurations.classpath.getDependencies().each { dep ->
+                    if (dep.group == "org.jetbrains.kotlin" && dep.name == "kotlin-gradle-plugin") {
+                        found = true
+                    }
+                }
+                if (found) {
+                    project.buildscript.dependencies.add("classpath", "org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.20")
+                }
             }
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx4096M -XX:MaxNewSize=3G
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=false
+kotlin.jvm.target.validation.mode=warning

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.1.3" apply false
+    id "com.android.application" version "8.7.0" apply false
     id "org.jetbrains.kotlin.android" version "2.0.20" apply false
 }
 


### PR DESCRIPTION
This PR upgrades the Gradle version used in the project from 7.6 to 8.11, because Gradle 7.6 is unsupported on Java 21 toolchain.


**Note**: it includes some hacks and dirty workarounds, only to ensure successful compilation. Please review all commits carefully before merging.