### PR TITLE
fix: #456

### DIFF
--- a/lib/page/danke/course_group_detail.dart
+++ b/lib/page/danke/course_group_detail.dart
@@ -206,31 +206,6 @@ class CourseGroupDetailState extends State<CourseGroupDetail> {
     _courseGroupFuture ??= _fetchCourseGroup();
     _reviewListFuture ??= _loadContent();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (mounted) {
-        if (locateReview != null) {
-          // Scroll to the specific floor.
-          final floorToJump = locateReview!;
-          _listViewController.scheduleLoadedCallback(
-              () async => await _listViewController.scrollToItem(floorToJump),
-              rebuild: true);
-          locateReview = null;
-        }
-
-        if (shouldScrollToEnd) {
-          try {
-            // Scroll to end.
-            _listViewController.scheduleLoadedCallback(
-                () async => await _listViewController.scrollToEnd(),
-                rebuild: true);
-            shouldScrollToEnd = false;
-          } catch (_) {
-            // we don't care if we failed to scroll to the end.
-          }
-        }
-      }
-    });
-
     return PlatformScaffold(
       iosContentPadding: false,
       iosContentBottomPadding: false,
@@ -294,6 +269,31 @@ class CourseGroupDetailState extends State<CourseGroupDetail> {
         child: FutureWidget<CourseGroup?>(
             future: _courseGroupFuture,
             successBuilder: (context, snapshot) {
+              WidgetsBinding.instance.addPostFrameCallback((_) async {
+                if (mounted) {
+                  if (locateReview != null) {
+                    // Scroll to the specific floor.
+                    final floorToJump = locateReview!;
+                    _listViewController.scheduleLoadedCallback(
+                            () async => await _listViewController.scrollToItem(floorToJump),
+                        rebuild: true);
+                    locateReview = null;
+                  }
+
+                  if (shouldScrollToEnd) {
+                    try {
+                      // Scroll to end.
+                      _listViewController.scheduleLoadedCallback(
+                              () async => await _listViewController.scrollToEnd(),
+                          rebuild: true);
+                      shouldScrollToEnd = false;
+                    } catch (_) {
+                      // we don't care if we failed to scroll to the end.
+                    }
+                  }
+                }
+              });
+
               return PagedListView<CourseReview>(
                 pagedController: _listViewController,
                 withScrollbar: true,


### PR DESCRIPTION
这个 PR 解决了 #456。该问题的原因是课评详情页面与论坛帖子页面不同，`PagedListView` 在 `FutureWidget` 中动态创建，`build()` 时可能对应的 `PagedListView` 根本还未创建，因此 `_state` 没有绑定。

该 PR 将其移动到 `PagedListView` 创建时的帧结束时执行。