### PR TITLE
Fix #475

### DIFF
--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -37,6 +37,7 @@ import 'package:dan_xi/repository/forum/forum_repository.dart';
 import 'package:dan_xi/util/master_detail_view.dart';
 import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
+import 'package:dan_xi/util/watermark.dart';
 import 'package:dan_xi/widget/forum/forum_widgets.dart';
 import 'package:dan_xi/widget/forum/ottag_selector.dart';
 import 'package:dan_xi/widget/forum/post_render.dart';
@@ -430,7 +431,7 @@ class BBSPostDetailState extends State<BBSPostDetail> {
           },
         ),
       ),
-    );
+    ).withWatermarkRegion();
   }
 
   // Load all floors, in case we have to scroll to end or to a specific floor

--- a/lib/page/forum/hole_messages.dart
+++ b/lib/page/forum/hole_messages.dart
@@ -22,6 +22,7 @@ import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/model/forum/message.dart';
 import 'package:dan_xi/page/subpage_forum.dart';
 import 'package:dan_xi/repository/forum/forum_repository.dart';
+import 'package:dan_xi/util/watermark.dart';
 import 'package:dan_xi/widget/libraries/paged_listview.dart';
 import 'package:dan_xi/widget/libraries/platform_app_bar_ex.dart';
 import 'package:dan_xi/widget/libraries/top_controller.dart';
@@ -144,6 +145,6 @@ class OTMessagesPageState extends State<OTMessagesPage> {
           ),
         ),
       ),
-    );
+    ).withWatermarkRegion();
   }
 }

--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -717,13 +717,8 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
               itemChanged: (index) {
                 if (index != pageIndex) {
                   // Dispatch [SubpageViewState] events.
-                  for (int i = 0; i < _subpage.length; i++) {
-                    if (index != i) {
-                      _subpage[i]
-                          .onViewStateChanged(SubpageViewState.INVISIBLE);
-                    }
-                  }
-                  _subpage[index].onViewStateChanged(SubpageViewState.VISIBLE);
+                  _subpage[pageIndex].onViewStateChanged(context, SubpageViewState.INVISIBLE);
+                  _subpage[index].onViewStateChanged(context, SubpageViewState.VISIBLE);
                   _pageIndex.value = index;
                 } else {
                   _subpage[index].onDoubleTapOnTab();

--- a/lib/page/platform_subpage.dart
+++ b/lib/page/platform_subpage.dart
@@ -93,11 +93,13 @@ abstract class PlatformSubpageState<T extends PlatformSubpage>
 
   Widget buildPage(BuildContext context);
 
+  @mustCallSuper
   void detachItself() {
     _isOnShow = false;
     _thisPrimaryScrollController?.detachPosition.call();
   }
 
+  @mustCallSuper
   void reattachItself() {
     _isOnShow = true;
     _thisPrimaryScrollController?.reattachPosition.call();
@@ -166,8 +168,7 @@ abstract class PlatformSubpageState<T extends PlatformSubpage>
             cupertino: (_, __) => CupertinoNavigationBarData(
               title: MediaQuery(
                   data: MediaQueryData(
-                      textScaler: TextScaler.linear(
-                          MediaQuery.textScaleFactorOf(context))),
+                      textScaler: MediaQuery.textScalerOf(context)),
                   child: TopController(child: widget.title(context))),
             ),
             material: (_, __) => MaterialAppBarData(

--- a/lib/page/platform_subpage.dart
+++ b/lib/page/platform_subpage.dart
@@ -42,7 +42,7 @@ abstract class PlatformSubpage<T> extends StatefulWidget {
   void onDoubleTapOnTab() {}
 
   @mustCallSuper
-  void onViewStateChanged(SubpageViewState state) =>
+  void onViewStateChanged(BuildContext parentContext, SubpageViewState state) =>
       Constant.eventBus.fire(_ViewStateChangedNotification<T>(state));
 }
 

--- a/lib/page/subpage_danke.dart
+++ b/lib/page/subpage_danke.dart
@@ -25,6 +25,7 @@ import 'package:dan_xi/provider/state_provider.dart';
 import 'package:dan_xi/repository/danke/curriculum_board_repository.dart';
 import 'package:dan_xi/repository/forum/forum_repository.dart';
 import 'package:dan_xi/util/master_detail_view.dart';
+import 'package:dan_xi/util/watermark.dart';
 import 'package:dan_xi/widget/danke/course_list_widget.dart';
 import 'package:dan_xi/widget/danke/course_search_bar.dart';
 import 'package:dan_xi/widget/danke/random_review_widgets.dart';
@@ -43,6 +44,21 @@ class DankeSubPage extends PlatformSubpage<DankeSubPage> {
 
   @override
   Create<Widget> get title => (cxt) => Text(S.of(cxt).curriculum);
+
+  @override
+  void onViewStateChanged(BuildContext parentContext, SubpageViewState state) {
+    super.onViewStateChanged(parentContext, state);
+    switch (state) {
+      case SubpageViewState.VISIBLE:
+      // Subpage is always mounted even if it is invisible.
+      // So we have to count on reattachItself/detachItself hooks to add/remove watermark.
+        Watermark.addWatermark(parentContext);
+        break;
+      case SubpageViewState.INVISIBLE:
+        Watermark.remove();
+        break;
+    }
+  }
 }
 
 class DankeSubPageState extends PlatformSubpageState<DankeSubPage> {

--- a/lib/page/subpage_danke.dart
+++ b/lib/page/subpage_danke.dart
@@ -51,7 +51,8 @@ class DankeSubPage extends PlatformSubpage<DankeSubPage> {
     switch (state) {
       case SubpageViewState.VISIBLE:
       // Subpage is always mounted even if it is invisible.
-      // So we have to count on reattachItself/detachItself hooks to add/remove watermark.
+      // Monitoring within State lifecycle methods like `initState` and `dispose` isn't effective.
+      // So we have to count on the onViewStateChanged hook to add/remove watermark.
         Watermark.addWatermark(parentContext);
         break;
       case SubpageViewState.INVISIBLE:

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -279,6 +279,21 @@ class ForumSubpage extends PlatformSubpage<ForumSubpage> {
 
   @override
   void onDoubleTapOnTab() => RefreshListEvent().fire();
+
+  @override
+  void onViewStateChanged(BuildContext parentContext, SubpageViewState state) {
+    super.onViewStateChanged(parentContext, state);
+    switch (state) {
+      case SubpageViewState.VISIBLE:
+        // Subpage is always mounted even if it is invisible.
+        // So we have to count on reattachItself/detachItself hooks to add/remove watermark.
+        Watermark.addWatermark(parentContext);
+        break;
+      case SubpageViewState.INVISIBLE:
+        Watermark.remove();
+        break;
+    }
+  }
 }
 
 class CreateNewPostEvent {}
@@ -541,9 +556,6 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
           });
         }),
         hashCode);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Watermark.addWatermark(context, rowCount: 4, columnCount: 8);
-    });
   }
 
   @override

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -286,7 +286,8 @@ class ForumSubpage extends PlatformSubpage<ForumSubpage> {
     switch (state) {
       case SubpageViewState.VISIBLE:
         // Subpage is always mounted even if it is invisible.
-        // So we have to count on reattachItself/detachItself hooks to add/remove watermark.
+        // Monitoring within State lifecycle methods like `initState` and `dispose` isn't effective.
+        // So we have to count on the onViewStateChanged hook to add/remove watermark.
         Watermark.addWatermark(parentContext);
         break;
       case SubpageViewState.INVISIBLE:

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -657,7 +657,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
           await AnnouncementRepository.getInstance().loadAnnouncements();
           bannerKey.currentState?.updateBannerList();
           // ... and scroll it to the top.
-          if (!mounted) return;
+          if (!context.mounted) return;
           try {
             await PrimaryScrollController.of(context).animateTo(0,
                 duration: const Duration(milliseconds: 200),

--- a/lib/util/watermark.dart
+++ b/lib/util/watermark.dart
@@ -39,7 +39,7 @@ class Watermark {
 
   /// Add a watermark to the screen.
   static void addWatermark(BuildContext context,
-      {int rowCount = 3, int columnCount = 10, TextStyle? textStyle}) async {
+      {int rowCount = 4, int columnCount = 8, TextStyle? textStyle}) async {
     if (overlayEntry != null) {
       // If the watermark is already added, remove it first so that the new one can be added.
       overlayEntry!.remove();

--- a/lib/util/watermark.dart
+++ b/lib/util/watermark.dart
@@ -20,13 +20,28 @@ import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/widget/forum/flutter_watermark_widget.dart';
 import 'package:flutter/material.dart';
 
+/// A reference-counted full-screen watermark that shows user ID overlay on the screen.
 class Watermark {
   static OverlayEntry? overlayEntry;
+
+  /// The reference count of the watermark. When it is 0, the watermark will be removed.
+  static int refCount = 0;
+
+  static void remove() {
+    assert(refCount > 0, 'The watermark reference count is already 0.');
+    refCount--;
+    if (refCount == 0) {
+      assert(overlayEntry != null, 'The watermark overlay entry is null.');
+      overlayEntry?.remove();
+      overlayEntry = null;
+    }
+  }
 
   /// Add a watermark to the screen.
   static void addWatermark(BuildContext context,
       {int rowCount = 3, int columnCount = 10, TextStyle? textStyle}) async {
     if (overlayEntry != null) {
+      // If the watermark is already added, remove it first so that the new one can be added.
       overlayEntry!.remove();
     }
 
@@ -48,5 +63,42 @@ class Watermark {
         ));
 
     overlayState.insert(overlayEntry!);
+    refCount++;
   }
+}
+
+/// A state widget that shows a full-screen watermark when the child widget is shown,
+/// and removes the watermark when the child widget is destroyed.
+///
+/// You can use the [withWatermarkRegion] extension method to wrap a widget with a watermark region.
+class WatermarkRegion extends StatefulWidget {
+  final Widget child;
+  const WatermarkRegion({super.key, required this.child});
+
+  @override
+  State<WatermarkRegion> createState() => _WatermarkRegionState();
+}
+
+class _WatermarkRegionState extends State<WatermarkRegion> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      Watermark.addWatermark(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+
+  @override
+  void dispose() {
+    Watermark.remove();
+    super.dispose();
+  }
+}
+
+extension WatermarkRegionExtension on Widget {
+  /// Wrap the widget with a watermark region.
+  Widget withWatermarkRegion() => WatermarkRegion(child: this);
 }

--- a/lib/widget/forum/forum_widgets.dart
+++ b/lib/widget/forum/forum_widgets.dart
@@ -32,6 +32,7 @@ import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/viewport_utils.dart';
+import 'package:dan_xi/util/watermark.dart';
 import 'package:dan_xi/widget/forum/render/base_render.dart';
 import 'package:dan_xi/widget/libraries/chip_widgets.dart';
 import 'package:dan_xi/widget/libraries/future_widget.dart';
@@ -675,7 +676,7 @@ class OTFloorMentionWidget extends StatelessWidget {
                 ),
               ),
             ],
-          );
+          ).withWatermarkRegion();
           if (PlatformX.isCupertino(context)) {
             return SafeArea(
               child: Card(


### PR DESCRIPTION
This PR:

1. implements reference counting for `Watermark`, allowing it to automatically hide when no longer required by any pages or widgets;
2. only sends `ViewStateChanged.INVISIBLE` event to the tab page that was just switched away from, to ensure that each page receives a matching and equal number of `VISIBLE` and `INVISIBLE` events.

Fixes #475.