### PR TITLE
Remove `bitsdojo_window` dependency

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:dan_xi/feature/feature_map.dart';
 import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/page/danke/course_group_detail.dart';
@@ -116,14 +115,6 @@ void main() {
       });
     });
   });
-
-  // Init DesktopWindow on desktop environment.
-  if (PlatformX.isDesktop) {
-    doWhenWindowReady(() {
-      final win = appWindow;
-      win.show();
-    });
-  }
 }
 
 class TouchMouseScrollBehavior extends MaterialScrollBehavior {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,7 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 #include <desktop_window/desktop_window_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_js/flutter_js_plugin.h>
@@ -18,9 +17,6 @@
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) bitsdojo_window_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "BitsdojoWindowPlugin");
-  bitsdojo_window_plugin_register_with_registrar(bitsdojo_window_linux_registrar);
   g_autoptr(FlPluginRegistrar) desktop_window_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWindowPlugin");
   desktop_window_plugin_register_with_registrar(desktop_window_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  bitsdojo_window_linux
   desktop_window
   file_selector_linux
   flutter_js

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,7 +1,6 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#include <bitsdojo_window_linux/bitsdojo_window_plugin.h>
 
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
@@ -59,7 +58,6 @@ static void my_application_activate(GApplication *application) {
     gtk_window_set_title(window, "dan_xi");
   }
 
-    bitsdojo_window_from(window);
     gtk_window_set_default_size(window, 1280, 720);
   gtk_widget_show(GTK_WIDGET(window));
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,6 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import bitsdojo_window_macos
 import desktop_window
 import device_info_plus
 import file_selector_macos
@@ -27,7 +26,6 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  BitsdojoWindowPlugin.register(with: registry.registrar(forPlugin: "BitsdojoWindowPlugin"))
   DesktopWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWindowPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,12 +1,7 @@
 import Cocoa
 import FlutterMacOS
-import bitsdojo_window_macos_v3
 
-class MainFlutterWindow: BitsdojoWindow {
-  override func bitsdojo_window_configure() -> UInt {
-    return BDW_HIDE_ON_STARTUP
-  }
-
+class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController.init()
     let windowFrame = self.frame

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -110,46 +110,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
-  bitsdojo_window:
-    dependency: "direct main"
-    description:
-      name: bitsdojo_window
-      sha256: "88ef7765dafe52d97d7a3684960fb5d003e3151e662c18645c1641c22b873195"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.6"
-  bitsdojo_window_linux:
-    dependency: transitive
-    description:
-      name: bitsdojo_window_linux
-      sha256: "9519c0614f98be733e0b1b7cb15b827007886f6fe36a4fb62cf3d35b9dd578ab"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4"
-  bitsdojo_window_macos:
-    dependency: transitive
-    description:
-      name: bitsdojo_window_macos
-      sha256: f7c5be82e74568c68c5b8449e2c5d8fd12ec195ecd70745a7b9c0f802bb0268f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4"
-  bitsdojo_window_platform_interface:
-    dependency: transitive
-    description:
-      name: bitsdojo_window_platform_interface
-      sha256: "65daa015a0c6dba749bdd35a0f092e7a8ba8b0766aa0480eb3ef808086f6e27c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
-  bitsdojo_window_windows:
-    dependency: transitive
-    description:
-      name: bitsdojo_window_windows
-      sha256: fa982cf61ede53f483e50b257344a1c250af231a3cdc93a7064dd6dc0d720b68
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.6"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,6 @@ dependencies:
   flutter_highlighting: ^0.9.0
   highlighting: ^0.9.0
   tray_manager: ^0.3.0
-  bitsdojo_window: ^0.1.6
   win32: ^5.0.2
   file_picker: ^8.1.2
   cached_network_image: ^3.2.1

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,6 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
 #include <desktop_window/desktop_window_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
@@ -24,8 +23,6 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  BitsdojoWindowPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("BitsdojoWindowPlugin"));
   DesktopWindowPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("DesktopWindowPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  bitsdojo_window_windows
   desktop_window
   file_selector_windows
   flutter_inappwebview_windows

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -5,8 +5,6 @@
 #include "flutter_window.h"
 #include "run_loop.h"
 #include "utils.h"
-#include <bitsdojo_window_windows/bitsdojo_window_plugin.h>
-auto bdw = bitsdojo_window_configure(BDW_HIDE_ON_STARTUP);
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {


### PR DESCRIPTION
The `bitsdojo_window` package was previously used to control window maximization and minimization. However, we've removed this functionality since 17e83792d25eadd31bc84638c43f042a8ee28206.

Currently, it serves no purpose and hasn't been maintained for >2 years.

This pull request will remove it. If similar functionality is needed in the future, the actively maintained [`window_manager`](https://pub.dev/packages/window_manager) package can be used instead.
