### PR TITLE
Fix web build

### DIFF
--- a/lib/util/js/js_web.dart
+++ b/lib/util/js/js_web.dart
@@ -15,9 +15,12 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import 'dart:js_interop/js_interop.dart';
+// fixme: json_serializable conflicts with @JS() annotation in [dart:js_interop]. (https://github.com/google/json_serializable.dart/issues/1391, https://github.com/google/json_serializable.dart/issues/1480)
+// As a workaround, we use the dart:_js_annotations library directly. It should be replaced with [dart:js_interop] when the issue is resolved.
+// ignore: IMPORT_INTERNAL_LIBRARY
+import 'dart:_js_annotations' as js;
 
-@JS('window.eval')
+@js.JS()
 external dynamic eval(dynamic arg);
 
 String evaluate(String jsCode) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,7 +103,7 @@ dependencies:
   tutorial_coach_mark: ^1.2.9
   flutter_platform_widgets: ^7.0.0
   intl: any
-  json_annotation: any
+  json_annotation: ^4.9.0
   flutter_cache_manager: any
   html: any
   cookie_jar: any


### PR DESCRIPTION
This PR fixes the broken GitHub action of building for the web platform by implementing a workaround.

`json_serializable` conflicts with `@JS()` annotation in `dart:js_interop`. (See https://github.com/google/json_serializable.dart/issues/1391, https://github.com/google/json_serializable.dart/issues/1480)

As a workaround, we use the `dart:_js_annotations` library directly.