### PR TITLE
upgrade: Flutter dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,24 +4,6 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
-}
-
-def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-if (flutterVersionCode == null) {
-    flutterVersionCode = '1'
-}
-
-def flutterVersionName = localProperties.getProperty('flutter.versionName')
-if (flutterVersionName == null) {
-    flutterVersionName = '1.0'
-}
-
 def keystoreProperties = new Properties()
 def keystorePropertiesFile = rootProject.file('key.properties')
 if (keystorePropertiesFile.exists()) {
@@ -49,10 +31,10 @@ android {
     defaultConfig {
         applicationId "io.github.danxi_dev.dan_xi"
         namespace "io.github.danxi_dev.dan_xi"
-        minSdkVersion 23
-        targetSdkVersion 35
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        minSdk 23
+        targetSdk 35
+        versionCode flutter.versionCode
+        versionName flutter.versionName
     }
     signingConfigs {
         release {

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.8.0" apply false
+    id "com.android.application" version "8.8.1" apply false
     id "org.jetbrains.kotlin.android" version "2.1.10" apply false
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -851,15 +851,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  fluttertoast:
-    dependency: "direct overridden"
-    description:
-      path: "."
-      ref: master
-      resolved-ref: "0edb4c7adf86f7245d99ee6ef12987a06653304d"
-      url: "https://github.com/ponnamkarthik/FlutterToast.git"
-    source: git
-    version: "8.2.11"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,10 +66,10 @@ packages:
     dependency: "direct dev"
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: "0c64e928dcbefddecd234205422bcfc2b5e6d31be0b86fef0d0dd48d7b4c9742"
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.4"
   args:
     dependency: "direct dev"
     description:
@@ -466,10 +466,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      sha256: "7423298f08f6fc8cce05792bae329f9a93653fc9c08712831b1a55540127995d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.3.7"
+    version: "9.0.2"
   file_selector_linux:
     dependency: transitive
     description:
@@ -953,8 +953,8 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "12454024d4a0cd3202887e54a14ad35087a24d51"
-      url: "https://github.com/dartclub/ical.git"
+      resolved-ref: e5eddf1a2ab52a1c004e75589756b959a45c3bb8
+      url: "https://github.com/Basis-Health/ical.git"
     source: git
     version: "0.3.0"
   image_picker:
@@ -1575,6 +1575,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: a0117dc2167805aa9125b82eee515cc891819bac2f538c83646d355b16f58b9a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.1"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -116,10 +116,6 @@ dependencies:
   pub_semver: ^2.1.4
 
 dependency_overrides:
-  fluttertoast:
-    git:
-      url: https://github.com/ponnamkarthik/FlutterToast.git
-      ref: master
   linkify:
     git:
       url: https://github.com/DanXi-Dev/linkify.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   super_sliver_list: ^0.4.0
   ical:
     git:
-      url: https://github.com/dartclub/ical.git
+      url: https://github.com/Basis-Health/ical.git
       ref: main
   url_launcher: ^6.1.12
   app_links: ^6.1.3
@@ -67,7 +67,7 @@ dependencies:
   flutter_highlighting: ^0.9.0
   highlighting: ^0.9.0
   win32: ^5.0.2
-  file_picker: ^8.1.2
+  file_picker: ^9.0.2
   cached_network_image: ^3.2.1
   flutter_typeahead: ^5.2.0
   collection: ">=1.15.0 <2.0.0"
@@ -116,7 +116,6 @@ dependencies:
   pub_semver: ^2.1.4
 
 dependency_overrides:
-  intl: ^0.19.0
   fluttertoast:
     git:
       url: https://github.com/ponnamkarthik/FlutterToast.git
@@ -134,7 +133,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   intl_utils: ^2.8.7
   # below used in build.dart
-  archive: ^3.4.10
+  archive: ^4.0.4
   git: ^2.2.1
   path: ^1.9.0
   args: ^2.4.2


### PR DESCRIPTION
This PR upgrades:

1. `ical`: `dartclub` is no longer maintained and hasn't upgraded its `intl` dependency in a long time. By switching to a more up-to-date fork, we can eliminate the need for `dependency_overrides` for `intl`;
2. `file_picker` & `archive`: minor updates.