### PR TITLE
feat: close #468

### DIFF
--- a/lib/repository/app/announcement_repository.dart
+++ b/lib/repository/app/announcement_repository.dart
@@ -178,6 +178,14 @@ class AnnouncementRepository {
         .map<Celebration>((e) => parseCelebration(e))
         .toList();
   }
+
+  List<int> getHighlightedTagIds() {
+    if (_tomlCache == null) {
+      return [];
+    }
+
+    return _tomlCache!['highlight_tag_ids'].cast<int>();
+  }
 }
 
 class UpdateInfo {

--- a/lib/widget/forum/forum_widgets.dart
+++ b/lib/widget/forum/forum_widgets.dart
@@ -24,6 +24,7 @@ import 'package:dan_xi/model/forum/report.dart';
 import 'package:dan_xi/page/forum/hole_detail.dart';
 import 'package:dan_xi/page/subpage_forum.dart';
 import 'package:dan_xi/provider/settings_provider.dart';
+import 'package:dan_xi/repository/app/announcement_repository.dart';
 import 'package:dan_xi/repository/forum/forum_repository.dart';
 import 'package:dan_xi/util/browser_util.dart';
 import 'package:dan_xi/util/forum/human_duration.dart';
@@ -81,6 +82,9 @@ Widget generateTagWidgets(BuildContext context, OTHole? e,
       color: useAccessibilityColoring
           ? Theme.of(context).textTheme.bodyLarge!.color
           : element.color,
+      highlighted: AnnouncementRepository.getInstance()
+          .getHighlightedTagIds()
+          .contains(element.tag_id),
     ));
   }
   return Wrap(

--- a/lib/widget/libraries/chip_widgets.dart
+++ b/lib/widget/libraries/chip_widgets.dart
@@ -63,12 +63,44 @@ class LeadingChip extends ChipWidget {
 
 /// A rectangular chip to match the style of the swift version of the forum.
 class RectangularChip extends ChipWidget {
-  const RectangularChip({super.key, super.label, super.onTap, super.color});
+  /// Is the chip highlighted?
+  ///
+  /// If true, the chip will have a gradient background and [color] will be ignored.
+  final bool highlighted;
+
+  const RectangularChip({super.key, super.label, super.onTap, super.color, this.highlighted = false});
 
   @override
   Widget build(BuildContext context) {
     final effectiveColor = color ?? Theme.of(context).colorScheme.primary;
     final lightness = HSLColor.fromColor(effectiveColor).lightness;
+    BoxDecoration backgroundDecor;
+    Color textColor;
+    if (highlighted) {
+      backgroundDecor = BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Colors.blue.withValues(alpha: 0.9),
+            Colors.purple.withValues(alpha: 0.9),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(2),
+      );
+      textColor = Colors.white;
+    } else {
+      backgroundDecor = BoxDecoration(
+        color: effectiveColor.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(2),
+      );
+      // Make text brighter under dark mode, and darker under light mode
+      textColor = PlatformX.isDarkMode
+          ? effectiveColor
+          .withLightness((lightness + 0.2).clamp(0, 1))
+          : effectiveColor
+          .withLightness((lightness - 0.2).clamp(0, 1));
+    }
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -77,22 +109,15 @@ class RectangularChip extends ChipWidget {
             onTap: onTap,
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-              decoration: BoxDecoration(
-                color: effectiveColor.withValues(alpha: 0.3),
-                borderRadius: BorderRadius.circular(2),
-              ),
+              decoration: backgroundDecor,
               child: Center(
                 child: Text(
                   label ?? "",
                   style: TextStyle(
                     fontSize: 12,
                     leadingDistribution: TextLeadingDistribution.even,
-                    // Make text brighter under dark mode, and darker under light mode
-                    color: PlatformX.isDarkMode
-                        ? effectiveColor
-                            .withLightness((lightness + 0.2).clamp(0, 1))
-                        : effectiveColor
-                            .withLightness((lightness - 0.2).clamp(0, 1)),
+
+                    color: textColor,
                   ),
                 ),
               ),


### PR DESCRIPTION
This PR closes #468.

We currently utilize 4 distinct Chip components: `Chip` (Material You's default Chip style), `LeadingChip` (for texts such as "Pinned" or "Deleted"), `RectangularChip` (Swift-style, mainly used in post lists to display tags), and `RoundChip` (originally a web-style, large-rounded-corner chip, currently only used on the blocked tag settings page when using the Cupertino theme).

I did implement the highlighting on `RoundChip` as well, but I felt its usage was too infrequent (currently, it's essentially non-existent for Material theme users), so I didn’t submit those changes.