### PR TITLE
fix: expand redirect code handling for WebVPN login

### DIFF
--- a/lib/util/io/dio_utils.dart
+++ b/lib/util/io/dio_utils.dart
@@ -45,6 +45,30 @@ class DioUtils {
             return status! < 400;
           });
 
+  /// Get the location to which the [response] is redirected.
+  ///
+  /// If the response is not a valid redirect response, return null.
+  ///
+  /// It doesn't check whether the "location" is empty, relative, etc.
+  /// You should do it yourself.
+  ///
+  /// ## Formality
+  /// This method is a bit different from the original one (see [HttpClientResponse.isRedirect] in `http_impl.dart`),
+  /// which considers the request HTTP method and excludes some invalid combinations (e.g., POST can only be redirected by 303).
+  /// But in practice, we don't need to (and cannot) be so strict. Some badly designed servers may return 302 for POST requests.
+  static String? getRedirectLocation(Response<dynamic> response) {
+    final statusCode = response.statusCode;
+    bool isRedirect = statusCode == HttpStatus.movedPermanently ||
+        statusCode == HttpStatus.permanentRedirect ||
+        statusCode == HttpStatus.found ||
+        statusCode == HttpStatus.seeOther ||
+        statusCode == HttpStatus.temporaryRedirect;
+    if (isRedirect) {
+      return response.headers['location']?[0];
+    }
+    return null;
+  }
+
   /// Process the redirect response manually and return the final response.
   ///
   /// What makes this method necessary is that the default behavior of [Dio] is
@@ -54,10 +78,8 @@ class DioUtils {
   static Future<Response<dynamic>> processRedirect(
       Dio dio, Response<dynamic> response) async {
     // Prevent the redirect being processed by HttpClient, with the 302 response caught manually.
-    if (response.statusCode == 302 &&
-        response.headers['location'] != null &&
-        response.headers['location']!.isNotEmpty) {
-      String location = response.headers['location']![0];
+    String? location = getRedirectLocation(response);
+    if (location != null) {
       if (location.isEmpty) return response;
       if (!Uri.parse(location).isAbsolute) {
         location = '${response.requestOptions.uri.origin}/$location';
@@ -110,7 +132,9 @@ class DioUtils {
   /// (The original [fetch] will throw a [DioException] WITHOUT the response data when [FormatException] occurs.)
   static Future<Response<T>> fetchWithJsonError<T>(
       Dio dio, RequestOptions options) async {
-    if (T == dynamic || options.responseType == ResponseType.bytes || options.responseType == ResponseType.stream) {
+    if (T == dynamic ||
+        options.responseType == ResponseType.bytes ||
+        options.responseType == ResponseType.stream) {
       // If T is dynamic, or the caller wants bytes or stream, just call the original fetch.
       // Because we are going to parse the response data as [String] below!
       return await dio.fetch(options) as Response<T>;

--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -158,7 +158,8 @@ class WebvpnProxy {
       Dio dio, IndependentCookieJar jar, PersonInfo? info) async {
     Response<dynamic>? res = await dio.get(WEBVPN_ID_REQUEST_URL,
         options: DioUtils.NON_REDIRECT_OPTION_WITH_FORM_TYPE);
-    if (res.statusCode == 302) {
+    if (DioUtils.getRedirectLocation(res) != null) {
+      // if we are redirected to UIS, we need to login to UIS first
       await DioUtils.processRedirect(dio, res);
       res = await UISLoginTool.loginUIS(dio, WEBVPN_UIS_LOGIN_URL, jar, info);
       if (res == null) {


### PR DESCRIPTION
We previously only considered 302 redirects for login, but the authentication address used by us (or WebVPN) might be deprecated, now returning 301 during WebVPN login, causing login failures.

This commit expands the handled redirect codes and removes the hardcoded 302 check.