### PR TITLE
Fix webvpn relative URL

### DIFF
--- a/lib/util/io/dio_utils.dart
+++ b/lib/util/io/dio_utils.dart
@@ -82,7 +82,7 @@ class DioUtils {
     if (location != null) {
       if (location.isEmpty) return response;
       if (!Uri.parse(location).isAbsolute) {
-        location = '${response.requestOptions.uri.origin}/$location';
+        location = '${response.requestOptions.uri.origin}$location';
       }
       return processRedirect(dio,
           await dio.get(location, options: NON_REDIRECT_OPTION_WITH_FORM_TYPE));

--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -156,6 +156,7 @@ class WebvpnProxy {
         // Temporary cookie jar
         IndependentCookieJar workJar = IndependentCookieJar();
         newDio.interceptors.add(CookieManager(workJar));
+        newDio.interceptors.add(DioLogInterceptor());
 
         loginSession = _authenticateWebVPN(newDio, workJar, _personInfo);
         await loginSession;

--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -91,7 +91,26 @@ class WebvpnProxy {
       return true;
     }
 
-    if (response.realUri.toString().startsWith(WEBVPN_LOGIN_URL)) {
+    /// Get the absolute final URL of the response (after all redirects).
+    ///
+    /// [response.realUri] is not always the final URL, because it may be a relative URL (i.e., /login).
+    String getAbsoluteFinalURL(Response<dynamic> response) {
+      final realUri = response.realUri;
+      if (realUri.isAbsolute) return realUri.toString();
+
+      // find the real origin in the reverse order
+      for (final redirect in response.redirects.reversed) {
+        if (redirect.location.isAbsolute) {
+          return redirect.location.origin + realUri.toString();
+        }
+      }
+
+      return response.requestOptions.uri.origin + realUri.toString();
+    }
+
+    final finalUrl = getAbsoluteFinalURL(response);
+    debugPrint("Response URL: $finalUrl");
+    if (finalUrl.startsWith(WEBVPN_LOGIN_URL)) {
       return true;
     }
 


### PR DESCRIPTION
This PR addresses the issue where the `isResponseRequiringLogin` function was incorrectly determining the necessity for re-login, due to overlooking the possibility that `response.realUri` could be a relative URL.

However, this fix does not fully resolve the problem where, after being forcibly logged out of WebVPN due to an IP address change and subsequently logging back in, the initial request invariably redirects to `/login`.  From the second request onward, the system responds as expected, even without requiring another login. We still need to investigate this problem further.