### PR TITLE
Update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ dmg 硬盘映像，挂载拷贝即可。
 
 ```shell
 $ flutter --version
-Flutter 3.29.0 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision 35c388afb5 (5 days ago) • 2025-02-10 12:48:41 -0800
-Engine • revision f73bfc4522
+Flutter 3.29.1 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 09de023485 (9 days ago) • 2025-02-28 13:44:05 -0800
+Engine • revision 871f65ac1b
 Tools • Dart 3.7.0 • DevTools 2.42.2
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,9 +63,9 @@ mount it.
 
 ```shell
 $ flutter --version
-Flutter 3.29.0 • channel stable • https://github.com/flutter/flutter.git
-Framework • revision 35c388afb5 (5 days ago) • 2025-02-10 12:48:41 -0800
-Engine • revision f73bfc4522
+Flutter 3.29.1 • channel stable • https://github.com/flutter/flutter.git
+Framework • revision 09de023485 (9 days ago) • 2025-02-28 13:44:05 -0800
+Engine • revision 871f65ac1b
 Tools • Dart 3.7.0 • DevTools 2.42.2
 ```
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -82,10 +82,10 @@ packages:
     dependency: "direct main"
     description:
       name: asn1lib
-      sha256: "1c296cd268f486cabcc3930e9b93a8133169305f18d722916e675959a88f6d2c"
+      sha256: "068190d6c99c436287936ba5855af2e1fa78d8083ae65b4db6a281780da727ae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.9"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -186,10 +186,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "8b158ab94ec6913e480dc3f752418348b5ae099eb75868b5f4775f0572999c61"
+      sha256: ea90e81dc4a25a043d9bee692d20ed6d1c4a1662a28c03a96417446c093ed6b4
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.4"
+    version: "8.9.5"
   cached_network_image:
     dependency: "direct main"
     description:
@@ -338,10 +338,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "610739247975c2d0de43482afa13ec1018f63c9fddf97ef3d8dc895faa3b4543"
+      sha256: "306b78788d1bb569edb7c55d622953c2414ca12445b41c9117963e03afc5c513"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.2"
+    version: "11.3.3"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -748,24 +748,24 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_platform_widgets
-      sha256: "84f39540cf433aa44b235b7fca6518d1bd30aa281d8196f00be60bc76cac96f4"
+      sha256: ba28f1a1ee7e46e2b7315405868c2d7126ba67e74e83e9a80538f8d5b5df7b21
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "8.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "1c2b787f99bdca1f3718543f81d38aa1b124817dfeb9fb196201bea85b6134bf"
+      sha256: "5a1e6fb2c0561958d7e4c33574674bda7b77caaca7a33b758876956f2902eea3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.26"
+    version: "2.0.27"
   flutter_progress_dialog:
     dependency: "direct main"
     description:
       path: "."
       ref: master
-      resolved-ref: cbacc685e38f917b183596c3be431cd58fdaef22
+      resolved-ref: "81169532b34fdc805daad784fbf16bf09d83a85d"
       url: "https://github.com/w568w/flutter_progress_dialog.git"
     source: git
     version: "0.1.1"
@@ -960,10 +960,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "82652a75e3dd667a91187769a6a2cc81bd8c111bbead698d8e938d2b63e5e89a"
+      sha256: "8bd392ba8b0c8957a157ae0dc9fcf48c58e6c20908d5880aea1d79734df090e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+21"
+    version: "0.8.12+22"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1353,10 +1353,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      sha256: "0ca7359dad67fd7063cb2892ab0c0737b2daafd807cf1acecd62374c8fae6c12"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.15"
+    version: "2.2.16"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1586,10 +1586,10 @@ packages:
     dependency: "direct main"
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pubspec_generator:
     dependency: "direct dev"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: quick_actions_android
-      sha256: a3ee27cbecbc3ac31ebf94cd343e0b8ca6a67975b1aa993704e7faf1df4661f0
+      sha256: "6d79aea8ad72696ac09d5c9dd9faf9e153775a5ec6224fadf5b9e8ad2d049bf3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.19"
+    version: "1.0.20"
   quick_actions_ios:
     dependency: transitive
     description:
@@ -1683,18 +1683,18 @@ packages:
     dependency: "direct main"
     description:
       name: screen_brightness
-      sha256: "99b898dae860ebe55fc872d8e300c6eafff3ee4ccb09301b90adb3f241f29874"
+      sha256: eca7bd9d2c3c688bcad14855361cab7097839400b6b4a56f62b7ae511c709958
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   screen_brightness_android:
     dependency: transitive
     description:
       name: screen_brightness_android
-      sha256: ff9141bed547db02233e7dd88f990ab01973a0c8a8c04ddb855c7b072f33409a
+      sha256: "6ba1b5812f66c64e9e4892be2d36ecd34210f4e0da8bdec6a2ea34f1aa42683e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   screen_brightness_ios:
     dependency: transitive
     description:
@@ -1763,10 +1763,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a768fc8ede5f0c8e6150476e14f38e2417c0864ca36bb4582be8e21925a03c22
+      sha256: "3ec7210872c4ba945e3244982918e502fa2bfb5230dff6832459ca0e1879b7ad"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.8"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -2056,10 +2056,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
+      sha256: "1d0eae19bd7606ef60fe69ef3b312a437a16549476c42321d5dc1506c9ca3bf4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.14"
+    version: "6.3.15"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -2255,4 +2255,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -106,7 +106,7 @@ dependencies:
   encrypt: any
   device_identity: ^1.0.0
   tutorial_coach_mark: ^1.2.9
-  flutter_platform_widgets: ^7.0.0
+  flutter_platform_widgets: ^8.0.0
   intl: any
   json_annotation: ^4.9.0
   flutter_cache_manager: any


### PR DESCRIPTION
This PR updates `flutter_platform_widgets` to version 8.0.0, as it includes support for Flutter 3.29, which is the version we are currently using.