### PR TITLE
Fix 519

### DIFF
--- a/lib/repository/fdu/ehall_repository.dart
+++ b/lib/repository/fdu/ehall_repository.dart
@@ -81,6 +81,12 @@ class FudanEhallRepository extends BaseRepositoryWithDio {
         () async => await _getStudentInfo(info),
         (_) async => await loginEhall(info),
         retryTimes: 3,
+        // If there is an explicit reason for UIS login failure, we should not retry anymore.
+        isFatalRetryError: (e) =>
+            e is CredentialsInvalidException ||
+            e is CaptchaNeededException ||
+            e is NetworkMaintenanceException ||
+            e is WeakPasswordException,
       );
 
   Future<StudentInfo> _getStudentInfo(PersonInfo info) async {

--- a/lib/repository/fdu/ehall_repository.dart
+++ b/lib/repository/fdu/ehall_repository.dart
@@ -15,16 +15,25 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import 'dart:convert';
+
 import 'package:dan_xi/model/person.dart';
 import 'package:dan_xi/repository/base_repository.dart';
 import 'package:dan_xi/repository/fdu/uis_login_tool.dart';
+import 'package:dan_xi/util/io/dio_utils.dart';
+import 'package:dan_xi/util/retrier.dart';
+import 'package:dan_xi/util/webvpn_proxy.dart';
 import 'package:dio/dio.dart';
 
 class FudanEhallRepository extends BaseRepositoryWithDio {
-  static const String _INFO_URL =
-      "https://ehall.fudan.edu.cn/jsonp/ywtb/info/getUserInfoAndSchoolInfo.json";
+  static const String _INFO_URL = "https://ehall.fudan.edu.cn/";
+  static const String _UIS_LOGIN_URL =
+      "https://uis.fudan.edu.cn/authserver/login?service=https%3A%2F%2Fid.fudan.edu.cn%2Fidp%2FthirdAuth%2Fcas";
+  static const String _ID_REQUEST_URL =
+      "https://id.fudan.edu.cn/idp/authCenter/authenticate?service=https%3A%2F%2Fehall.fudan.edu.cn%2Fmanage%2Fcommon%2Fcas_login%2F30001%3Fredirect%3Dhttps%253A%252F%252Fehall.fudan.edu.cn";
   static const String _LOGIN_URL =
-      "https://uis.fudan.edu.cn/authserver/login?service=http%3A%2F%2Fehall.fudan.edu.cn%2Flogin%3Fservice%3Dhttp%3A%2F%2Fehall.fudan.edu.cn%2Fywtb-portal%2Ffudan%2Findex.html";
+      "https://ehall.fudan.edu.cn/manage/common/cas_login/30001";
+  static Future<void>? loginSession;
 
   FudanEhallRepository._();
 
@@ -32,22 +41,71 @@ class FudanEhallRepository extends BaseRepositoryWithDio {
 
   factory FudanEhallRepository.getInstance() => _instance;
 
-  Future<StudentInfo> getStudentInfo(PersonInfo info) async =>
-      UISLoginTool.tryAsyncWithAuth(
-          dio, _LOGIN_URL, cookieJar!, info, _getStudentInfo);
-
-  Future<StudentInfo> _getStudentInfo() async {
-    Response<Map<String, dynamic>> rep = await dio.get(_INFO_URL);
-    Map<String, dynamic> rawJson = rep.data!;
-    if (rawJson['data']['userName'] == null) {
-      throw GeneralLoginFailedException();
+  /// fixme: This method is essentially the same as the one in [WebvpnProxy._authenticateWebVPN].
+  ///
+  /// We should consider refactoring this to avoid code duplication.
+  Future<void> _authenticateEhall(PersonInfo info) async {
+    Response<dynamic>? res = await dio.get(_ID_REQUEST_URL,
+        options: DioUtils.NON_REDIRECT_OPTION_WITH_FORM_TYPE);
+    if (DioUtils.getRedirectLocation(res) != null) {
+      // if we are redirected to UIS, we need to login to UIS first
+      await DioUtils.processRedirect(dio, res);
+      res = await UISLoginTool.loginUIS(dio, _UIS_LOGIN_URL, cookieJar!, info);
+      if (res == null) throw Exception("UIS login failed");
     }
-    return StudentInfo(rawJson['data']['userName'],
-        rawJson['data']['userTypeName'], rawJson['data']['userDepartment']);
+    final ticket = WebvpnProxy.retrieveTicket(res);
+
+    Map<String, dynamic> queryParams = {
+      'redirect': 'https://ehall.fudan.edu.cn',
+      'ticket': ticket,
+    };
+
+    final response = await dio.get(_LOGIN_URL,
+        queryParameters: queryParams,
+        options: DioUtils.NON_REDIRECT_OPTION_WITH_FORM_TYPE);
+    await DioUtils.processRedirect(dio, response);
+  }
+
+  Future<void> loginEhall(PersonInfo info) async {
+    if (loginSession != null) {
+      await loginSession;
+    } else {
+      loginSession = _authenticateEhall(info);
+      await loginSession!;
+      loginSession = null;
+    }
+  }
+
+  Future<StudentInfo> getStudentInfo(PersonInfo info) async =>
+      Retrier.tryAsyncWithFix(
+        () async => await _getStudentInfo(info),
+        (_) async => await loginEhall(info),
+        retryTimes: 3,
+      );
+
+  Future<StudentInfo> _getStudentInfo(PersonInfo info) async {
+    Response<dynamic> res = await dio.get(_INFO_URL,
+        options: DioUtils.NON_REDIRECT_OPTION_WITH_FORM_TYPE);
+    res = await DioUtils.processRedirect(dio, res);
+    final htmlStr = res.data.toString();
+    RegExp userInfoMatcher = RegExp(
+        r'window\.userInfoDSL\s*=\s*({[\s\S]*?})(?=\s*\n|$)',
+        dotAll: true);
+    final match = userInfoMatcher.firstMatch(htmlStr);
+    if (match == null) {
+      throw Exception("Failed to parse user info");
+    }
+    final jsonStr = match.group(1)!;
+    Map<String, dynamic> userInfo = jsonDecode(jsonStr);
+    if (userInfo.isEmpty) {
+      throw Exception("Empty user info");
+    }
+    return StudentInfo(
+        userInfo['name'], userInfo['identity'], userInfo['depart']);
   }
 
   @override
-  String get linkHost => "fudan.edu.cn";
+  String get linkHost => "ehall.fudan.edu.cn";
 }
 
 class StudentInfo {

--- a/lib/repository/fdu/uis_login_tool.dart
+++ b/lib/repository/fdu/uis_login_tool.dart
@@ -147,7 +147,7 @@ class UISLoginTool {
     } else if (response.data.toString().contains(UNDER_MAINTENANCE)) {
       throw NetworkMaintenanceException();
     } else if (response.data.toString().contains(WEAK_PASSWORD)) {
-      throw GeneralLoginFailedException();
+      throw WeakPasswordException();
     }
 
     jar.cloneFrom(workJar);
@@ -161,4 +161,4 @@ class CredentialsInvalidException implements Exception {}
 
 class NetworkMaintenanceException implements Exception {}
 
-class GeneralLoginFailedException implements Exception {}
+class WeakPasswordException implements Exception {}

--- a/lib/repository/fdu/uis_login_tool.dart
+++ b/lib/repository/fdu/uis_login_tool.dart
@@ -87,6 +87,12 @@ class UISLoginTool {
       },
       retryTimes: retryTimes,
       isFatalError: isFatalError,
+      // If there is an explicit reason for UIS login failure, we should not retry anymore.
+      isFatalRetryError: (e) =>
+          e is CredentialsInvalidException ||
+          e is CaptchaNeededException ||
+          e is NetworkMaintenanceException ||
+          e is WeakPasswordException,
     );
   }
 

--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -187,7 +187,7 @@ class WebvpnProxy {
         throw WebvpnRequestException("Failed to login to UIS");
       }
     }
-    final ticket = _retrieveTicket(res);
+    final ticket = retrieveTicket(res);
 
     Map<String, dynamic> queryParams = {
       'cas_login': 'true',
@@ -200,7 +200,7 @@ class WebvpnProxy {
     await DioUtils.processRedirect(dio, response);
   }
 
-  static String? _retrieveTicket(Response<dynamic> response) {
+  static String? retrieveTicket(Response<dynamic> response) {
     // Check if the URL host matches the expected value
     if (response.realUri.host != "id.fudan.edu.cn") {
       return null;

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -124,7 +124,7 @@ class LoginDialogState extends State<LoginDialog> {
           try {
             newInfo.name = await CardRepository.getInstance().getName(newInfo);
             if (newInfo.name?.isEmpty ?? true) {
-              throw WeakPasswordException();
+              throw Exception("Unable to get user name");
             }
             await newInfo.saveToSharedPreferences(widget.sharedPreferences!);
             widget.personInfo.value = newInfo;
@@ -201,6 +201,7 @@ class LoginDialogState extends State<LoginDialog> {
         context,
         error,
         stackTrace: stack,
+        buttonText: "", // hide the button
         errorMessageTextStyle: const TextStyle(fontSize: 12, color: Colors.red),
       );
       refreshSelf();

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -28,6 +28,7 @@ import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/shared_preferences.dart';
+import 'package:dan_xi/widget/libraries/error_page_widget.dart';
 import 'package:dan_xi/widget/libraries/platform_context_menu.dart';
 import 'package:dan_xi/widget/libraries/with_scrollbar.dart';
 import 'package:dio/dio.dart';
@@ -82,7 +83,7 @@ class LoginDialog extends StatefulWidget {
 class LoginDialogState extends State<LoginDialog> {
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _pwdController = TextEditingController();
-  String _errorText = "";
+  Widget _errorWidget = SizedBox.shrink();
   static const DEFAULT_USERGROUP = UserGroup.FUDAN_UNDERGRADUATE_STUDENT;
   UserGroup _group = DEFAULT_USERGROUP;
 
@@ -123,7 +124,7 @@ class LoginDialogState extends State<LoginDialog> {
           try {
             newInfo.name = await CardRepository.getInstance().getName(newInfo);
             if (newInfo.name?.isEmpty ?? true) {
-              throw GeneralLoginFailedException();
+              throw WeakPasswordException();
             }
             await newInfo.saveToSharedPreferences(widget.sharedPreferences!);
             widget.personInfo.value = newInfo;
@@ -190,19 +191,18 @@ class LoginDialogState extends State<LoginDialog> {
   }
 
   void _executeLogin() {
-    _tryLogin(_nameController.text, _pwdController.text).catchError((error) {
+    _tryLogin(_nameController.text, _pwdController.text)
+        .catchError((error, stack) {
       if (error is CredentialsInvalidException) {
         _pwdController.text = "";
-        _errorText = S.of(context).credentials_invalid;
-      } else if (error is CaptchaNeededException) {
-        _errorText = S.of(context).captcha_needed;
-      } else if (error is NetworkMaintenanceException) {
-        _errorText = S.of(context).under_maintenance;
-      } else if (error is GeneralLoginFailedException) {
-        _errorText = S.of(context).weak_password;
-      } else {
-        _errorText = S.of(context).connection_failed;
       }
+      if (!mounted) return;
+      _errorWidget = ErrorPageWidget.buildWidget(
+        context,
+        error,
+        stackTrace: stack,
+        errorMessageTextStyle: const TextStyle(fontSize: 12, color: Colors.red),
+      );
       refreshSelf();
     });
   }
@@ -253,11 +253,7 @@ class LoginDialogState extends State<LoginDialog> {
                 ),
               ],
 
-              Text(
-                _errorText,
-                textAlign: TextAlign.start,
-                style: const TextStyle(fontSize: 12, color: Colors.red),
-              ),
+              _errorWidget,
               TextField(
                 controller: _nameController,
                 enabled: _group != UserGroup.VISITOR,


### PR DESCRIPTION
This PR:

1.  Fixes #519, **adapting to Ehall's new login authentication method** (similar to WebVPN).
    -   **Note**: The current implementation temporarily duplicates the same logic. Since the login logic for Ehall and WebVPN is identical, they should be merged in the future.
2.  Enhances error display in the login dialog. **The dialog now provides a complete error description and stack trace**, replacing vague messages like "登录失败，请稍后重试".
3.  Fixes a long-standing issue in `Retrier` where **it would discard the original error's stack trace, making error tracing extremely difficult**.
4.  Optimizes login performance by **preventing retries for certain specific errors (e.g., incorrect password)** and exiting the request function immediately upon error.