### PR TITLE
fix: #525

### DIFF
--- a/lib/page/forum/hole_editor.dart
+++ b/lib/page/forum/hole_editor.dart
@@ -333,54 +333,56 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
     return showPlatformModalSheet(
         context: context,
         builder: (BuildContext context) {
-          final Widget body = Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ListTile(
-                      leading: const Icon(Icons.emoji_emotions),
-                      title: Text(S.of(context).sticker)),
-                  // const Divider(),
-                  Expanded(
-                    child: SingleChildScrollView(
-                      scrollDirection: Axis.vertical,
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: LayoutGrid(
-                          columnSizes: List.filled(stickerSheetColumns, 1.fr),
-                          rowSizes: List.filled(stickerSheetRows, auto),
-                          rowGap: 8,
-                          columnGap: 8,
-                          children: Stickers.values.map((e) {
-                            return Container(
-                              alignment: Alignment.center,
-                              child: InkWell(
-                                onTap: () {
-                                  var cursorPosition =
-                                      widget.controller.selection.base.offset;
-                                  cursorPosition = cursorPosition == -1
-                                      ? widget.controller.text.length
-                                      : cursorPosition;
-                                  widget.controller.text =
-                                      "${widget.controller.text.substring(0, cursorPosition)}![](${e.name})${widget.controller.text.substring(cursorPosition)}";
-                                  Navigator.of(context).pop();
-                                },
-                                child: Image.asset(
-                                  getStickerAssetPath(e.name)!,
-                                  width: 60,
-                                  height: 60,
-                                  fit: BoxFit.contain,
+          final Widget body = SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ListTile(
+                        leading: const Icon(Icons.emoji_emotions),
+                        title: Text(S.of(context).sticker)),
+                    // const Divider(),
+                    Expanded(
+                      child: SingleChildScrollView(
+                        scrollDirection: Axis.vertical,
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: LayoutGrid(
+                            columnSizes: List.filled(stickerSheetColumns, 1.fr),
+                            rowSizes: List.filled(stickerSheetRows, auto),
+                            rowGap: 8,
+                            columnGap: 8,
+                            children: Stickers.values.map((e) {
+                              return Container(
+                                alignment: Alignment.center,
+                                child: InkWell(
+                                  onTap: () {
+                                    var cursorPosition =
+                                        widget.controller.selection.base.offset;
+                                    cursorPosition = cursorPosition == -1
+                                        ? widget.controller.text.length
+                                        : cursorPosition;
+                                    widget.controller.text =
+                                        "${widget.controller.text.substring(0, cursorPosition)}![](${e.name})${widget.controller.text.substring(cursorPosition)}";
+                                    Navigator.of(context).pop();
+                                  },
+                                  child: Image.asset(
+                                    getStickerAssetPath(e.name)!,
+                                    width: 60,
+                                    height: 60,
+                                    fit: BoxFit.contain,
+                                  ),
                                 ),
-                              ),
-                            );
-                          }).toList(),
+                              );
+                            }).toList(),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ]),
+                  ]),
+            ),
           );
           return PlatformX.isCupertino(context)
               ? ConstrainedBox(

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -348,8 +348,8 @@ class LoginDialogState extends State<LoginDialog> {
     );
   }
 
-  _showSwitchGroupModal() {
-    return showPlatformModalSheet(
+  Future<void> _showSwitchGroupModal() async {
+    await showPlatformModalSheet(
         context: context,
         builder: (context) => PlatformContextMenu(
             actions: _buildLoginAsList(context),

--- a/lib/widget/libraries/platform_context_menu.dart
+++ b/lib/widget/libraries/platform_context_menu.dart
@@ -22,13 +22,17 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 class PlatformContextMenu extends StatelessWidget {
   final Widget? cancelButton;
   final List<Widget> actions;
+  final bool useSafeArea;
 
   const PlatformContextMenu(
-      {super.key, this.cancelButton, required this.actions});
+      {super.key,
+      this.cancelButton,
+      required this.actions,
+      this.useSafeArea = true});
 
   @override
   Widget build(BuildContext context) {
-    return PlatformWidget(
+    Widget widget = PlatformWidget(
         cupertino: (_, __) => CupertinoActionSheet(
               actions: actions,
               cancelButton: cancelButton,
@@ -39,6 +43,7 @@ class PlatformContextMenu extends StatelessWidget {
                 children: actions,
               ),
             ));
+    return useSafeArea ? SafeArea(child: widget) : widget;
   }
 }
 


### PR DESCRIPTION
Generally, as both Android 15+ and iOS utilize edge-to-edge layouts, any non-scrolling layout displayed within a `PlatformModalSheet` should be wrapped in a `SafeArea` widget to prevent content at the bottom from being obscured.

This is by design, not a Flutter bug.

Fix #525.