### PR TITLE
chore: use aspectRatio instead of width in tablet detection

### DIFF
--- a/lib/util/master_detail_utils.dart
+++ b/lib/util/master_detail_utils.dart
@@ -20,5 +20,5 @@ import 'package:flutter/widgets.dart';
 const kTabletMasterContainerWidth = 370.0;
 
 bool isTablet(BuildContext context) {
-  return MediaQuery.of(context).size.width >= 768.0;
+  return MediaQuery.sizeOf(context).aspectRatio >= 1.5;
 }


### PR DESCRIPTION
IMHO in tablet detection `aspectRatio` is better than `width`.