### PR TITLE
feat: Add extra haptic feedback and configuration

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -559,5 +559,7 @@
   "select_date_range_to": "To",
   "select_date_range_far_past": "Far Past",
   "select_date_range_now": "Now",
-  "hole_force_deleted": "Deleted"
+  "hole_force_deleted": "Deleted",
+  "haptic_feedback": "Haptic Feedback",
+  "haptic_feedback_description": "Provide vibration feedback during interactions"
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -541,5 +541,7 @@
   "select_date_range_to": "終了：",
   "select_date_range_far_past": "遠い過去",
   "select_date_range_now": "現在",
-  "hole_force_deleted": "削除され"
+  "hole_force_deleted": "削除され",
+  "haptic_feedback": "触覚フィードバック",
+  "haptic_feedback_description": "操作時に振動フィードバックを提供"
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -553,5 +553,7 @@
   "select_date_range_to": "到",
   "select_date_range_far_past": "遥远的过去",
   "select_date_range_now": "现在",
-  "hole_force_deleted": "已删除"
+  "hole_force_deleted": "已删除",
+  "haptic_feedback": "触觉反馈",
+  "haptic_feedback_description": "在操作时提供震动反馈"
 }

--- a/lib/page/forum/hole_search.dart
+++ b/lib/page/forum/hole_search.dart
@@ -27,6 +27,7 @@ import 'package:dan_xi/util/lazy_future.dart';
 import 'package:dan_xi/util/master_detail_view.dart';
 import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/widget/dialogs/care_dialog.dart';
 import 'package:dan_xi/widget/libraries/future_widget.dart';
 import 'package:dan_xi/widget/libraries/platform_app_bar_ex.dart';
@@ -280,6 +281,7 @@ Widget searchByTextGeneral(
           ? const Icon(Icons.text_fields)
           : const Icon(CupertinoIcons.search),
       onTap: () async {
+        HapticFeedbackUtil.light();
         submit(context, searchKeyword);
         bool isCareWordsDetected = await detectCareWords(searchKeyword);
         if (context.mounted && isCareWordsDetected) {
@@ -314,6 +316,7 @@ Widget searchByPid(BuildContext context, String searchKeyword,
           : const Icon(CupertinoIcons.arrow_right_square),
       title: Text(S.of(context).search_by_pid_tip(pidMatch.group(0)!)),
       onTap: () {
+        HapticFeedbackUtil.light();
         submit(context, searchKeyword);
         goToPIDResultPage(context, int.parse(pidMatch.group(1)!));
       },
@@ -333,6 +336,7 @@ Widget searchByFloorId(BuildContext context, String searchKeyword,
           : const Icon(CupertinoIcons.arrow_right_square),
       title: Text(S.of(context).search_by_floor_tip(floorMatch.group(0)!)),
       onTap: () {
+        HapticFeedbackUtil.light();
         submit(context, searchKeyword);
         goToFloorIdResultPage(context, int.parse(floorMatch.group(1)!));
       },
@@ -357,6 +361,7 @@ Widget searchByTag(BuildContext context, String searchKeyword,
                     leading: Icon(PlatformIcons(context).tag),
                     title: Text(S.of(context).search_by_tag_tip(e.name!)),
                     onTap: () {
+                      HapticFeedbackUtil.light();
                       submit(context, searchKeyword);
                       smartNavigatorPush(context, '/bbs/discussions',
                           arguments: {"tagFilter": e.name},

--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -45,6 +45,7 @@ import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/stream_listener.dart';
 import 'package:dan_xi/util/webvpn_proxy.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/widget/dialogs/login_dialog.dart';
 import 'package:dan_xi/widget/dialogs/qr_code_dialog.dart';
 import 'package:dan_xi/widget/forum/post_render.dart';
@@ -643,11 +644,14 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
             child: ListTile(
               leading: Icon(PlatformIcons(context).accountCircle),
               title: Text(S.of(context).login),
-              onTap: () => LoginDialog.showLoginDialog(
+              onTap: () { 
+                HapticFeedbackUtil.light();
+                LoginDialog.showLoginDialog(
                   context,
                   SettingsProvider.getInstance().preferences,
                   StateProvider.personInfo,
-                  false),
+                  false);
+                  },
             ),
           )
         ]),
@@ -720,6 +724,7 @@ class HomePageState extends State<HomePage> with WidgetsBindingObserver {
                   return;
                 }
                 if (index != pageIndex) {
+                  HapticFeedbackUtil.medium();
                   // Dispatch [SubpageViewState] events.
                   _subpage[pageIndex]
                       .onViewStateChanged(context, SubpageViewState.INVISIBLE);

--- a/lib/page/platform_subpage.dart
+++ b/lib/page/platform_subpage.dart
@@ -19,6 +19,7 @@ import 'package:dan_xi/common/constant.dart';
 import 'package:dan_xi/page/home_page.dart';
 import 'package:dan_xi/util/scroller_fix/mirror_scroll_controller.dart';
 import 'package:dan_xi/util/stream_listener.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/widget/libraries/top_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
@@ -144,7 +145,10 @@ abstract class PlatformSubpageState<T extends PlatformSubpage>
               MaterialIconButtonData(tooltip: leadingItems.first.caption),
           padding: EdgeInsets.zero,
           icon: leadingItems.first.widget,
-          onPressed: leadingItems.first.onPressed,
+          onPressed: () {
+            HapticFeedbackUtil.light();
+            leadingItems.first.onPressed?.call();
+            },
         );
       }
     }
@@ -156,7 +160,10 @@ abstract class PlatformSubpageState<T extends PlatformSubpage>
             material: (_, __) => MaterialIconButtonData(tooltip: e.caption),
             padding: EdgeInsets.zero,
             icon: e.widget,
-            onPressed: e.onPressed);
+            onPressed: () {
+              HapticFeedbackUtil.light();
+              e.onPressed?.call();
+              });
       }).toList();
     }
 

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -39,6 +39,7 @@ import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/stream_listener.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/widget/forum/auto_banner.dart';
 import 'package:dan_xi/widget/forum/forum_widgets.dart';
 import 'package:dan_xi/widget/forum/login_widgets.dart';
@@ -851,8 +852,11 @@ Widget buildForumTopBar() => Selector<ForumProvider, bool>(
                     : EdgeInsets.zero,
                 child: PlatformIconButton(
                   icon: Icon(PlatformIcons(context).search),
-                  onPressed: () => smartNavigatorPush(context, '/bbs/search',
-                      forcePushOnMainNavigator: true),
+                  onPressed: () { 
+                    HapticFeedbackUtil.light();
+                    smartNavigatorPush(context, '/bbs/search',
+                      forcePushOnMainNavigator: true);
+                      },
                 ),
               ),
               const OTTitle()

--- a/lib/page/subpage_settings.dart
+++ b/lib/page/subpage_settings.dart
@@ -36,6 +36,7 @@ import 'package:dan_xi/util/master_detail_view.dart';
 import 'package:dan_xi/util/noticing.dart';
 import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/viewport_utils.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/util/win32/auto_start.dart'
     if (dart.library.html) 'package:dan_xi/util/win32/auto_start_stub.dart';
 import 'package:dan_xi/widget/dialogs/swatch_picker_dialog.dart';
@@ -351,9 +352,11 @@ class SettingsPageState extends State<SettingsPage> {
                             leading: PlatformX.isMaterial(context)
                                 ? const Icon(Icons.account_circle)
                                 : const Icon(CupertinoIcons.person_circle),
-                            subtitle: Text(
-                                "${StateProvider.personInfo.value!.name} (${StateProvider.personInfo.value!.id})"),
+                            subtitle: Text(StateProvider.personInfo.value != null 
+                                ? "${StateProvider.personInfo.value!.name} (${StateProvider.personInfo.value!.id})"
+                                : S.of(context).not_logged_in),
                             onTap: () {
+                              HapticFeedbackUtil.medium();
                               showPlatformDialog(
                                 context: context,
                                 barrierDismissible: false,
@@ -377,6 +380,7 @@ class SettingsPageState extends State<SettingsPage> {
                                                   .error),
                                         ),
                                         onPressed: () {
+                                          HapticFeedbackUtil.heavy();
                                           Navigator.of(context).pop();
                                           _deleteAllDataAndExit();
                                         })
@@ -395,15 +399,18 @@ class SettingsPageState extends State<SettingsPage> {
                             subtitle: Text(SettingsProvider.getInstance()
                                 .campus
                                 .displayTitle(context)),
-                            onTap: () => showPlatformModalSheet(
+                            onTap: () {
+                              HapticFeedbackUtil.light();
+                              showPlatformModalSheet(
                                 context: context,
                                 builder: (BuildContext sheetContext) =>
                                     PlatformContextMenu(
                                         actions: _buildCampusAreaList(sheetContext),
                                         cancelButton: CupertinoActionSheetAction(
                                                 child: Text(S.of(sheetContext).cancel),
-                                                onPressed: () => 
-                                                    Navigator.of(sheetContext).pop()))),
+                                                onPressed: () =>
+                                                    Navigator.of(sheetContext).pop())));
+                              },
                           ),
                         ]),
                       ),
@@ -419,7 +426,9 @@ class SettingsPageState extends State<SettingsPage> {
                               subtitle: Text(SettingsProvider.getInstance()
                                   .language
                                   .displayTitle(context)),
-                              onTap: () => showPlatformModalSheet(
+                              onTap: () {
+                                HapticFeedbackUtil.light();
+                                showPlatformModalSheet(
                                   context: context,
                                   builder: (BuildContext sheetContext) =>
                                       PlatformContextMenu(
@@ -427,7 +436,8 @@ class SettingsPageState extends State<SettingsPage> {
                                           cancelButton: CupertinoActionSheetAction(
                                                   child: Text(S.of(sheetContext).cancel),
                                                   onPressed: () => 
-                                                      Navigator.of(sheetContext).pop()))),
+                                                      Navigator.of(sheetContext).pop())));
+                                                      },
                             ),
 
                             Selector<SettingsProvider, bool>(
@@ -442,6 +452,7 @@ class SettingsPageState extends State<SettingsPage> {
                                     const Icon(Icons.accessibility_new_rounded),
                                 value: value,
                                 onChanged: (bool value) {
+                                  HapticFeedbackUtil.selection();
                                   SettingsProvider.getInstance()
                                       .useAccessibilityColoring = value;
                                   forumPageKey.currentState?.setState(() {});
@@ -466,6 +477,7 @@ class SettingsPageState extends State<SettingsPage> {
                                   onTap: isFollowingSystemPalette
                                       ? null // Set onTap to null when disabled
                                       : () async {
+                                          HapticFeedbackUtil.light();
                                           int initialColor = context.read<SettingsProvider>().primarySwatch;
 
                                           MaterialColor? result =
@@ -499,6 +511,7 @@ class SettingsPageState extends State<SettingsPage> {
                                     secondary: const Icon(Icons.palette_outlined),
                                     value: followSystemPaletteValue,
                                     onChanged: (bool value) {
+                                      HapticFeedbackUtil.selection();
                                       context.read<SettingsProvider>().followSystemPalette = value;
                                     },
                                   );
@@ -513,7 +526,9 @@ class SettingsPageState extends State<SettingsPage> {
                                       .displayTitle(context) ??
                                   "null"),
                               leading: const Icon(Icons.brightness_4),
-                              onTap: () => showPlatformModalSheet(
+                              onTap: () {
+                                HapticFeedbackUtil.light();
+                                showPlatformModalSheet(
                                   context: context,
                                   builder: (BuildContext sheetContext) =>
                                       PlatformContextMenu(
@@ -521,7 +536,8 @@ class SettingsPageState extends State<SettingsPage> {
                                           cancelButton: CupertinoActionSheetAction(
                                                   child: Text(S.of(sheetContext).cancel),
                                                   onPressed: () => 
-                                                  Navigator.of(sheetContext).pop()))),
+                                                  Navigator.of(sheetContext).pop())));
+                                                  },
                             ),
                             ListTile(
                               title: Text(S.of(context).proxy_setting),
@@ -531,6 +547,7 @@ class SettingsPageState extends State<SettingsPage> {
                                       S.of(context).proxy_setting_unset),
                               leading: const Icon(Icons.network_ping),
                               onTap: () async {
+                                HapticFeedbackUtil.light();
                                 String? addr = await Noticing.showInputDialog(
                                     context,
                                     S.of(context).proxy_setting_input_title,
@@ -557,10 +574,28 @@ class SettingsPageState extends State<SettingsPage> {
                                     .of(context)
                                     .show_hidden_notifications_description),
                                 leading: const Icon(Icons.notifications_off),
-                                onTap: () => context
+                                onTap: () { 
+                                      HapticFeedbackUtil.light();
+                                      context
                                         .read<SettingsProvider>()
-                                        .hiddenNotifications = [],
+                                        .hiddenNotifications = [];
+                                      }
                               ),
+                            SwitchListTile.adaptive(
+                              title: Text(S.of(context).haptic_feedback),
+                              subtitle: Text(S.of(context).haptic_feedback_description),
+                              secondary: PlatformX.isMaterial(context)
+                                  ? const Icon(Icons.vibration)
+                                  : const Icon(CupertinoIcons.hand_raised),
+                              value: context.select<SettingsProvider, bool>(
+                                  (s) => s.hapticFeedbackEnabled),
+                              onChanged: (bool value) {
+                                context.read<SettingsProvider>().hapticFeedbackEnabled = value;
+                                if (value) {
+                                  HapticFeedback.selectionClick();
+                                }
+                              },
+                            ),
                             SwitchListTile.adaptive(
                                 title: Text(S.of(context).use_webvpn_title),
                                 secondary: const Icon(Icons.network_cell),
@@ -569,6 +604,7 @@ class SettingsPageState extends State<SettingsPage> {
                                 value: context.select<SettingsProvider, bool>(
                                     (s) => s.useWebvpn),
                                 onChanged: (bool value) async {
+                                   HapticFeedbackUtil.selection();
                                   context.read<SettingsProvider>().useWebvpn =
                                       value;
                                 })
@@ -703,6 +739,7 @@ class SettingsPageState extends State<SettingsPage> {
                             snapshot.data!.config!.show_folded!)
                         .displayTitle(context)!),
                     onTap: () {
+                      HapticFeedbackUtil.light();
                       showPlatformModalSheet(
                           context: context,
                           builder: (BuildContext sheetContext) =>
@@ -721,7 +758,10 @@ class SettingsPageState extends State<SettingsPage> {
                         ? const Icon(Icons.hide_image)
                         : const Icon(CupertinoIcons.eye_slash),
                     subtitle: Text(S.of(context).fatal_error),
-                    onTap: () => setState(() {}),
+                    onTap: () { 
+                      HapticFeedbackUtil.light();
+                      setState(() {});
+                    }
                   ),
                   loadingBuilder: (context) => ListTile(
                     title: Text(S.of(context).forum_nsfw_behavior),
@@ -729,7 +769,10 @@ class SettingsPageState extends State<SettingsPage> {
                         ? const Icon(Icons.hide_image)
                         : const Icon(CupertinoIcons.eye_slash),
                     subtitle: Text(S.of(context).loading),
-                    onTap: () => setState(() {}),
+                    onTap: () { 
+                      HapticFeedbackUtil.light();
+                      setState(() {});
+                    }
                   ),
                 ),
                 OTNotificationSettingsTile(onSettingsUpdate: () => setState(() {})),
@@ -740,9 +783,11 @@ class SettingsPageState extends State<SettingsPage> {
                           subtitle:
                               Text(S.of(context).forum_show_banner_description),
                           value: value,
-                          onChanged: (bool value) =>
-                              SettingsProvider.getInstance().isBannerEnabled =
-                                  value,
+                          onChanged: (bool value) {
+                            HapticFeedbackUtil.light();
+                            SettingsProvider.getInstance().isBannerEnabled =
+                                  value;
+                                  },
                         ),
                     selector: (_, model) => model.isBannerEnabled),
                 Selector<SettingsProvider, bool>(
@@ -753,6 +798,7 @@ class SettingsPageState extends State<SettingsPage> {
                               Text(S.of(context).forum_clean_mode_description),
                           value: value,
                           onChanged: (bool value) {
+                            HapticFeedbackUtil.light();
                             if (value) {
                               _showCleanModeGuideDialog();
                             }
@@ -788,15 +834,19 @@ class SettingsPageState extends State<SettingsPage> {
                     title: Text(S.of(context).recommended_tags),
                     leading: const Icon(Icons.recommend),
                     subtitle: Text(S.of(context).unavailable),
-                    onTap: () => Noticing.showModalNotice(context,
+                    onTap: () { 
+                      HapticFeedbackUtil.light();
+                      Noticing.showModalNotice(context,
                         title: S.of(context).recommended_tags,
-                        message: S.of(context).recommended_tags_description),
+                        message: S.of(context).recommended_tags_description);
+                        },
                   ),
                 ListTile(
                   leading: Icon(PlatformIcons(context).tag),
                   title: Text(S.of(context).forum_hidden_tags),
                   subtitle: Text(S.of(context).forum_hidden_tags_description),
                   onTap: () async {
+                    HapticFeedbackUtil.light();
                     await smartNavigatorPush(context, '/bbs/tags/blocklist');
                     forumPageKey.currentState?.setState(() {});
                   },
@@ -806,6 +856,7 @@ class SettingsPageState extends State<SettingsPage> {
                   title: Text(S.of(context).background_image),
                   subtitle: Text(S.of(context).background_image_description),
                   onTap: () async {
+                    HapticFeedbackUtil.light();
                     if (SettingsProvider.getInstance().backgroundImagePath ==
                         null) {
                       final ImagePickerProxy picker =
@@ -847,6 +898,7 @@ class SettingsPageState extends State<SettingsPage> {
                   subtitle: Text(_clearCacheSubtitle ??
                       S.of(context).clear_cache_description),
                   onTap: () async {
+                    HapticFeedbackUtil.light();
                     await DefaultCacheManagerWithWebvpn().emptyCache();
                     setState(() {
                       _clearCacheSubtitle = S.of(context).cache_cleared;
@@ -860,6 +912,7 @@ class SettingsPageState extends State<SettingsPage> {
                       subtitle: const Text(
                           "[WARNING: DEBUG FEATURE] Disable Markdown Rendering"),
                       onTap: () {
+                        HapticFeedbackUtil.light();
                         SettingsProvider.getInstance()
                                 .isMarkdownRenderingEnabled =
                             !SettingsProvider.getInstance()
@@ -868,35 +921,50 @@ class SettingsPageState extends State<SettingsPage> {
                 ListTile(
                   leading: nil,
                   title: Text(S.of(context).modify_password),
-                  onTap: () => BrowserUtil.openUrl(
-                      Constant.FORUM_FORGOT_PASSWORD_URL, context),
+                  onTap: () { 
+                    HapticFeedbackUtil.light();
+                    BrowserUtil.openUrl(
+                      Constant.FORUM_FORGOT_PASSWORD_URL, context);
+                      }
                 ),
                 ListTile(
                   leading: nil,
                   title: Text(S.of(context).list_my_posts),
-                  onTap: () => smartNavigatorPush(context, '/bbs/discussions',
+                  onTap: () {
+                    HapticFeedbackUtil.light();
+                    smartNavigatorPush(context, '/bbs/discussions',
                       arguments: {'showFilterByMe': true},
-                      forcePushOnMainNavigator: true),
+                      forcePushOnMainNavigator: true);
+                      }
                 ),
                 ListTile(
                   leading: nil,
                   title: Text(S.of(context).list_my_replies),
-                  onTap: () => smartNavigatorPush(context, '/bbs/postDetail',
+                  onTap: () {
+                    HapticFeedbackUtil.light();
+                    smartNavigatorPush(context, '/bbs/postDetail',
                       arguments: {'myReplies': true},
-                      forcePushOnMainNavigator: true),
+                      forcePushOnMainNavigator: true);
+                      }
                 ),
                 ListTile(
                   leading: nil,
                   title: Text(S.of(context).list_view_history),
-                  onTap: () => smartNavigatorPush(context, '/bbs/postDetail',
+                  onTap: () {
+                    HapticFeedbackUtil.light();
+                    smartNavigatorPush(context, '/bbs/postDetail',
                       arguments: {'viewHistory': true},
-                      forcePushOnMainNavigator: true),
+                      forcePushOnMainNavigator: true);
+                      }
                 ),
                 ListTile(
                   leading: nil,
                   title: Text(S.of(context).list_my_punishments),
-                  onTap: () => smartNavigatorPush(context, "/bbs/postDetail",
-                      arguments: {"punishmentHistory": true}),
+                  onTap: () {
+                    HapticFeedbackUtil.light();
+                    smartNavigatorPush(context, "/bbs/postDetail",
+                      arguments: {"punishmentHistory": true});
+                      }
                 ),
               ],
               ListTile(
@@ -914,6 +982,7 @@ class SettingsPageState extends State<SettingsPage> {
                       ),
                 onTap: () async {
                   if (!context.read<ForumProvider>().isUserInitialized) {
+                    HapticFeedbackUtil.light();
                     if (SettingsProvider.getInstance().forumToken == null) {
                       Noticing.showNotice(
                           context, S.of(context).login_from_forum_page,
@@ -923,11 +992,14 @@ class SettingsPageState extends State<SettingsPage> {
                       onLogout();
                       setState(() {});
                     }
-                  } else if (await Noticing.showConfirmationDialog(
+                  } else {
+                    HapticFeedbackUtil.medium();
+                    if (await Noticing.showConfirmationDialog(
                           context, S.of(context).logout_forum,
                           title: S.of(context).logout,
                           isConfirmDestructive: true) ==
                       true) {
+                        HapticFeedbackUtil.heavy();
                     if (!mounted) return;
                     ProgressFuture progressDialog = showProgressDialog(
                         loadingText: S.of(context).logout, context: context);
@@ -940,6 +1012,7 @@ class SettingsPageState extends State<SettingsPage> {
                           .notifyUpdate();
                     } finally {
                       progressDialog.dismiss(showAnim: false);
+                    }
                     }
                   }
                 },
@@ -1011,7 +1084,10 @@ class SettingsPageState extends State<SettingsPage> {
                           fit: BoxFit.fill, image: AssetImage(e.imageUrl)))),
               title: Text(e.name),
               //subtitle: Text(e.description),
-              onTap: () => BrowserUtil.openUrl(e.url, context),
+              onTap: () { 
+                HapticFeedbackUtil.light();
+                BrowserUtil.openUrl(e.url, context);
+                }
             ))
         .toList();
     return Card(
@@ -1081,7 +1157,10 @@ class SettingsPageState extends State<SettingsPage> {
                         render: kMarkdownRenderFactory(null),
                         content: S.of(context).acknowledgements_markdown,
                         hasBackgroundImage: false,
-                        onTapLink: (url) => BrowserUtil.openUrl(url!, null),
+                        onTapLink: (url) {
+                          HapticFeedbackUtil.light();
+                          BrowserUtil.openUrl(url!, null);
+                          }
                       ),
 
                       const SizedBox(height: 16),
@@ -1135,6 +1214,7 @@ class SettingsPageState extends State<SettingsPage> {
                         return TextButton(
                           child: Text(S.of(context).rate),
                           onPressed: () {
+                            HapticFeedbackUtil.light();
                             inAppReview.openStoreListing(
                               appStoreId: Constant.APPSTORE_APPID,
                             );
@@ -1147,6 +1227,7 @@ class SettingsPageState extends State<SettingsPage> {
                     TextButton(
                       child: Text(S.of(context).contact_us),
                       onPressed: () async {
+                        HapticFeedbackUtil.light();
                         bool? sendEmail = await Noticing.showConfirmationDialog(
                             context,
                             S
@@ -1171,6 +1252,7 @@ class SettingsPageState extends State<SettingsPage> {
                     TextButton(
                       child: Text(S.of(context).project_page),
                       onPressed: () {
+                        HapticFeedbackUtil.light();
                         BrowserUtil.openUrl(S.of(context).project_url, context);
                       },
                     ),
@@ -1178,6 +1260,7 @@ class SettingsPageState extends State<SettingsPage> {
                     TextButton(
                       child: Text(S.of(context).diagnostic_information),
                       onPressed: () {
+                        HapticFeedbackUtil.light();
                         smartNavigatorPush(context, "/diagnose");
                       },
                     ),

--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -92,6 +92,7 @@ class SettingsProvider with ChangeNotifier {
   static const String KEY_USE_WEBVPN = "use_webvpn";
   static const String KEY_VIEW_HISTORY = "view_history";
   static const String KEY_FOLLOW_SYSTEM_PALETTE = "follow_system_palette";
+  static const String KEY_HAPTIC_FEEDBACK_ENABLED = "haptic_feedback_enabled";
 
   static const int MAX_VIEW_HISTORY = 250;
 
@@ -797,13 +798,26 @@ class SettingsProvider with ChangeNotifier {
     if (preferences!.containsKey(KEY_FOLLOW_SYSTEM_PALETTE)) {
       return preferences!.getBool(KEY_FOLLOW_SYSTEM_PALETTE)!;
     }
-    return false; // Default to false if not set
+    return false;
   }
 
   set followSystemPalette(bool value) {
     preferences!.setBool(KEY_FOLLOW_SYSTEM_PALETTE, value);
     notifyListeners();
   }
+
+  bool get hapticFeedbackEnabled {
+    if (preferences!.containsKey(KEY_HAPTIC_FEEDBACK_ENABLED)) {
+      return preferences!.getBool(KEY_HAPTIC_FEEDBACK_ENABLED)!;
+    }
+    return false;
+  }
+
+  set hapticFeedbackEnabled(bool value) {
+    preferences!.setBool(KEY_HAPTIC_FEEDBACK_ENABLED, value);
+      notifyListeners();
+  }
+
 }
 
 enum SortOrder { LAST_REPLIED, LAST_CREATED }

--- a/lib/util/haptic_feedback_util.dart
+++ b/lib/util/haptic_feedback_util.dart
@@ -1,0 +1,47 @@
+/*
+ *     Copyright (C) 2021  DanXi-Dev
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter/services.dart';
+import 'package:dan_xi/provider/settings_provider.dart';
+
+class HapticFeedbackUtil {
+  static void light() {
+    if (SettingsProvider.getInstance().hapticFeedbackEnabled) {
+      // HapticFeedback.lightImpact();   // IDK WHY, For some reason, it's reversed here.
+      HapticFeedback.heavyImpact();
+    }
+  }
+  
+  static void medium() {
+    if (SettingsProvider.getInstance().hapticFeedbackEnabled) {
+      HapticFeedback.mediumImpact();
+    }
+  }
+  
+  static void heavy() {
+    if (SettingsProvider.getInstance().hapticFeedbackEnabled) {
+      // HapticFeedback.heavyImpact();   // IDK WHY, For some reason, it's reversed here.
+      HapticFeedback.lightImpact();
+    }
+  }
+  
+  static void selection() {
+    if (SettingsProvider.getInstance().hapticFeedbackEnabled) {
+      HapticFeedback.selectionClick();
+    }
+  }
+}

--- a/lib/widget/feature_item/feature_list_item.dart
+++ b/lib/widget/feature_item/feature_list_item.dart
@@ -18,6 +18,7 @@
 import 'package:dan_xi/feature/base_feature.dart';
 import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:flutter/material.dart';
 
 /// A simple implementation of [FeatureContainerState] to show the feature as a [ListTile].
@@ -69,7 +70,10 @@ class FeatureListItemState extends State<FeatureListItem>
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: widget.feature.customSubtitle ?? Text(summary.join("\n")),
-        onTap: widget.feature.clickable ? widget.feature.onTap : null,
+        onTap: widget.feature.clickable ? () {
+          HapticFeedbackUtil.light();
+          widget.feature.onTap?.call();
+        } : null,
       );
       widget.feature.onEvent(FeatureEvent.CREATE);
       return tile;
@@ -87,9 +91,11 @@ class FeatureListItemState extends State<FeatureListItem>
           overflow: TextOverflow.ellipsis,
         ),
         subtitle: Text(S.of(context).tap_to_view),
-        onTap: () => setState(() {
+        onTap: () { 
+          HapticFeedbackUtil.light();
+          setState(() {
           loadWidget = true;
-        }),
+        });}
       );
     }
   }

--- a/lib/widget/forum/forum_widgets.dart
+++ b/lib/widget/forum/forum_widgets.dart
@@ -35,6 +35,7 @@ import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/viewport_utils.dart';
 import 'package:dan_xi/util/watermark.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 import 'package:dan_xi/widget/forum/render/base_render.dart';
 import 'package:dan_xi/widget/libraries/chip_widgets.dart';
 import 'package:dan_xi/widget/libraries/future_widget.dart';
@@ -238,8 +239,11 @@ class OTHoleWidget extends StatelessWidget {
                       ]),
                     ]),
               ]),
-              onTap: () => smartNavigatorPush(context, "/bbs/postDetail",
-                  arguments: {"post": postElement})),
+              onTap: () { 
+                HapticFeedbackUtil.light();
+                smartNavigatorPush(context, "/bbs/postDetail",
+                  arguments: {"post": postElement});
+                  }),
         ],
       ),
     );
@@ -527,7 +531,10 @@ class OTFloorWidget extends StatelessWidget {
     );
 
     final card = GestureDetector(
-      onLongPress: onLongPress,
+      onLongPress: () {
+        HapticFeedbackUtil.medium();
+        onLongPress?.call();
+        },
       child: Card(
         color: isInMention && PlatformX.isCupertino(context)
             ? Theme.of(context).dividerColor.withValues(alpha: 0.05)
@@ -887,6 +894,7 @@ class OTFloorToolBarState extends State<OTFloorToolBar> {
         OTFloorWidgetBottomBarButton(
           text: "${floor.like}",
           onTap: () async {
+            HapticFeedbackUtil.light();
             try {
               floor.liked ??= false;
               setState(() {
@@ -911,6 +919,7 @@ class OTFloorToolBarState extends State<OTFloorToolBar> {
         OTFloorWidgetBottomBarButton(
           text: "${floor.dislike}",
           onTap: () async {
+            HapticFeedbackUtil.light();
             try {
               floor.disliked ??= false;
               setState(() {

--- a/lib/widget/libraries/material_x.dart
+++ b/lib/widget/libraries/material_x.dart
@@ -16,6 +16,7 @@
  */
 
 import 'package:flutter/material.dart';
+import 'package:dan_xi/util/haptic_feedback_util.dart';
 
 class ExpansionTileX extends StatefulWidget {
   /// Creates a single-line [ListTile] with an expansion arrow icon that expands or collapses
@@ -226,6 +227,7 @@ class _ExpansionTileXState extends State<ExpansionTileX>
   }
 
   void _handleTap() {
+    HapticFeedbackUtil.light();
     setState(() {
       _isExpanded = !_isExpanded;
       if (_isExpanded) {


### PR DESCRIPTION
P.S.
Given that both Samsung and Xiaomi have reversed `heavyImpact()` and `lightImpact()`, the corresponding implementations of these two parts in `util/haptic_feedback_util.dart` have been reversed accordingly.
The original vibration implementation for `onRefresh` has been retained to maintain the basic vibration feedback when Haptic Feedback is not enabled.