### PR TITLE
fix: #549

### DIFF
--- a/lib/page/subpage_settings.dart
+++ b/lib/page/subpage_settings.dart
@@ -21,6 +21,7 @@ import 'package:dan_xi/common/constant.dart';
 import 'package:dan_xi/common/pubspec.yaml.g.dart';
 import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/model/forum/user.dart';
+import 'package:dan_xi/model/person.dart';
 import 'package:dan_xi/page/home_page.dart';
 import 'package:dan_xi/page/settings/open_source_license.dart';
 import 'package:dan_xi/page/subpage_forum.dart';
@@ -402,7 +403,7 @@ class SettingsPageState extends State<SettingsPage> {
                                         actions: _buildCampusAreaList(sheetContext),
                                         cancelButton: CupertinoActionSheetAction(
                                                 child: Text(S.of(sheetContext).cancel),
-                                                onPressed: () => 
+                                                onPressed: () =>
                                                     Navigator.of(sheetContext).pop()))),
                           ),
                         ]),
@@ -426,7 +427,7 @@ class SettingsPageState extends State<SettingsPage> {
                                           actions: _buildLanguageList(sheetContext),
                                           cancelButton: CupertinoActionSheetAction(
                                                   child: Text(S.of(sheetContext).cancel),
-                                                  onPressed: () => 
+                                                  onPressed: () =>
                                                       Navigator.of(sheetContext).pop()))),
                             ),
 
@@ -520,7 +521,7 @@ class SettingsPageState extends State<SettingsPage> {
                                           actions: _buildThemeList(sheetContext),
                                           cancelButton: CupertinoActionSheetAction(
                                                   child: Text(S.of(sheetContext).cancel),
-                                                  onPressed: () => 
+                                                  onPressed: () =>
                                                   Navigator.of(sheetContext).pop()))),
                             ),
                             ListTile(
@@ -561,17 +562,28 @@ class SettingsPageState extends State<SettingsPage> {
                                         .read<SettingsProvider>()
                                         .hiddenNotifications = [],
                               ),
-                            SwitchListTile.adaptive(
-                                title: Text(S.of(context).use_webvpn_title),
-                                secondary: const Icon(Icons.network_cell),
-                                subtitle:
-                                    Text(S.of(context).use_webvpn_description),
-                                value: context.select<SettingsProvider, bool>(
-                                    (s) => s.useWebvpn),
-                                onChanged: (bool value) async {
-                                  context.read<SettingsProvider>().useWebvpn =
-                                      value;
-                                })
+                            ValueListenableBuilder<PersonInfo?>(
+                              valueListenable: StateProvider.personInfo,
+                              builder: (context, personInfo, __) {
+                                final isVisitor =
+                                    personInfo?.group == UserGroup.VISITOR;
+                                return SwitchListTile.adaptive(
+                                  title: Text(S.of(context).use_webvpn_title),
+                                  secondary: const Icon(Icons.network_cell),
+                                  subtitle:
+                                      Text(S.of(context).use_webvpn_description),
+                                  value: context.select<SettingsProvider, bool>(
+                                      (s) => s.useWebvpn),
+                                  onChanged: isVisitor
+                                      ? null
+                                      : (bool value) async {
+                                          context
+                                              .read<SettingsProvider>()
+                                              .useWebvpn = value;
+                                        },
+                                );
+                              },
+                            )
                           ],
                         ),
                       ),

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -39,6 +39,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:flutter_progress_dialog/flutter_progress_dialog.dart';
+import 'package:provider/provider.dart';
 
 const kCompatibleUserGroup = [
   UserGroup.FUDAN_UNDERGRADUATE_STUDENT,
@@ -102,7 +103,7 @@ class LoginDialogState extends State<LoginDialog> {
         await newInfo.saveToSharedPreferences(widget.sharedPreferences!);
         widget.personInfo.value = newInfo;
         // disable WebVPN by default in VISITOR mode
-        SettingsProvider.getInstance().useWebvpn = false;
+        context.read<SettingsProvider>().useWebvpn = false;
         progressDialog.dismiss(showAnim: false);
         Navigator.of(context).pop();
         showFAQ();

--- a/lib/widget/dialogs/login_dialog.dart
+++ b/lib/widget/dialogs/login_dialog.dart
@@ -18,6 +18,7 @@
 import 'package:dan_xi/common/constant.dart';
 import 'package:dan_xi/generated/l10n.dart';
 import 'package:dan_xi/model/person.dart';
+import 'package:dan_xi/provider/settings_provider.dart';
 import 'package:dan_xi/repository/fdu/ecard_repository.dart';
 import 'package:dan_xi/repository/fdu/ehall_repository.dart';
 import 'package:dan_xi/repository/fdu/uis_login_tool.dart';
@@ -100,6 +101,8 @@ class LoginDialogState extends State<LoginDialog> {
             PersonInfo(id, password, "No User Account", UserGroup.VISITOR);
         await newInfo.saveToSharedPreferences(widget.sharedPreferences!);
         widget.personInfo.value = newInfo;
+        // disable WebVPN by default in VISITOR mode
+        SettingsProvider.getInstance().useWebvpn = false;
         progressDialog.dismiss(showAnim: false);
         Navigator.of(context).pop();
         showFAQ();


### PR DESCRIPTION
When logging in as visitor, this PR:

1. sets `useWebvpn` to `false`;
2. greys out the WebVPN switch in the setting.

Fixes #549.