### PR TITLE
feat: support export timetable as csv file

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -419,6 +419,7 @@
   "settings": "Settings",
   "share": "Share",
   "share_as_ics": "Export as ICS",
+  "share_as_csv": "Export as CSV file compatible with WakeUp Timetable import",
   "show": "Show",
   "show_all": "Show All",
   "show_all_replies": "Show All",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -411,6 +411,7 @@
   "settings": "設定",
   "share": "シェア",
   "share_as_ics": "ICSとしてエクスポート",
+  "share_as_csv": "WakeUp時間割にインポート可能なCSVファイルとしてエクスポート",
   "show": "表示",
   "show_all": "すべて表示",
   "show_all_replies": "すべて表示",

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -413,6 +413,7 @@
   "settings": "设置",
   "share": "分享",
   "share_as_ics": "导出为 ICS",
+  "share_as_csv": "导出为可供 WakeUp 课程表导入的 CSV 文件",
   "show": "显示",
   "show_all": "显示全部",
   "show_all_replies": "查看全部",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,6 @@ import 'package:dan_xi/page/settings/hidden_tags_preference.dart';
 import 'package:dan_xi/page/settings/open_source_license.dart';
 import 'package:dan_xi/page/subpage_forum.dart';
 import 'package:dan_xi/provider/forum_provider.dart';
-import 'package:dan_xi/repository/app/announcement_repository.dart';
 import 'package:dan_xi/provider/language_manager.dart';
 import 'package:dan_xi/provider/notification_provider.dart';
 import 'package:dan_xi/page/subpage_settings.dart';

--- a/lib/page/subpage_timetable.dart
+++ b/lib/page/subpage_timetable.dart
@@ -283,7 +283,10 @@ class TimetableSubPageState extends PlatformSubpageState<TimetableSubPage> {
     }
     super.initState();
     _setContent();
-    converters = {S.current.share_as_ics: ICSConverter()};
+    converters = {
+      S.current.share_as_ics: ICSConverter(),
+      S.current.share_as_csv: CSVConverter()
+    };
     _shareSubscription.bindOnlyInvalid(
         Constant.eventBus.on<ShareTimetableEvent>().listen((_) {
           if (_table == null) return;


### PR DESCRIPTION
WakeUp 课程表支持桌面小组件，看课表比较方便。教务系统改版后，WakeUp 课程表无法获取到新学期的课表数据，因此添加功能，支持导出可以被 WakeUp 课程表导入的 CSV 文件