### PR TITLE
tryfix: #587

### DIFF
--- a/lib/repository/fdu/neo_login_tool.dart
+++ b/lib/repository/fdu/neo_login_tool.dart
@@ -161,6 +161,7 @@ class FudanSession {
             // CookieManager merges headers from both the existing request and the cookie jar,
             // so reusing the same RequestOptions would accumulate stale cookies.
             final reqCopy = req.copyWith();
+            // Work around Dio bug: FormData objects can only be used once
             if (reqCopy.data is FormData) {
               reqCopy.data = (reqCopy.data as FormData).clone();
             }
@@ -200,6 +201,7 @@ class FudanSession {
             // CookieManager merges headers from both the existing request and the cookie jar,
             // so reusing the same RequestOptions would accumulate stale cookies.
             final reqCopy = req.copyWith();
+            // Work around Dio bug: FormData objects can only be used once
             if (reqCopy.data is FormData) {
               reqCopy.data = (reqCopy.data as FormData).clone();
             }
@@ -234,6 +236,7 @@ class FudanSession {
             // CookieManager merges headers from both the existing request and the cookie jar,
             // so reusing the same RequestOptions would accumulate stale cookies.
             final reqCopy = req.copyWith();
+            // Work around Dio bug: FormData objects can only be used once
             if (reqCopy.data is FormData) {
               reqCopy.data = (reqCopy.data as FormData).clone();
             }


### PR DESCRIPTION
This PR fixes a long-standing bug where `RequestOptions` contains mutable fields - for example, `headers` - that `CookieIntercepter` treats as a base and appends to, rather than overwriting.

As a result, when an initial request fails, the retry request carries over artifacts (such as incorrect `ticket` cookies) generated and added during the previous attempt.

This behavior likely caused the following issues:

* **"Forum" page infinite loading on startup:** Requires a manual refresh to load normally.
* **"Forum" page infinite loading after backgrounding:** Occurs when the app is left in the background for an extended period, requiring an app restart to recover.

To prevent retries from carrying over unnecessary mutable state, this PR clones `RequestOptions` for each request to avoid side effects.

Fixes #587.