### PR TITLE
fix: use GET to log in the webvpn to avoid incorrect redirect

### DIFF
--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -147,8 +147,10 @@ class WebVPNInterceptor extends Interceptor {
       debugPrint(
           "Requesting through WebVPN: ${options.method} ${options.path}");
       final proxiedResponse = await FudanSession.request(
-          options, validateResponse,
-          manualLoginUrl: WEBVPN_LOGIN_URL);
+        options, validateResponse,
+        manualLoginUrl: WEBVPN_LOGIN_URL,
+        manualLoginMethod: "GET",
+      );
       return handler.resolve(proxiedResponse, true);
     } on DioException catch (e) {
       return handler.reject(e, true);


### PR DESCRIPTION
Fixes #643.