### PR TITLE
fix: add version check for `webkit_web_view_get_theme_color`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -687,12 +687,13 @@ packages:
     source: hosted
     version: "1.2.0-beta.3"
   flutter_inappwebview_linux:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: flutter_inappwebview_linux
-      sha256: "2e1a3b09bb911fb5a8bb155cb7f1eb1428a19b6e20363b9db48beef428b8cef5"
-      url: "https://pub.dev"
-    source: hosted
+      path: flutter_inappwebview_linux
+      ref: "20260215/fix-webkit-check-version"
+      resolved-ref: "4c71f22252d2ad5e8dfd4e37085e0ddf6785f4fe"
+      url: "https://github.com/sseu-buhzzi/flutter_inappwebview.git"
+    source: git
     version: "0.1.0-beta.1"
   flutter_inappwebview_macos:
     dependency: transitive
@@ -2140,26 +2141,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.28.0"
+    version: "1.29.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.15"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -125,6 +125,13 @@ dependency_overrides:
       ref: patch-2
       path: flutter_secure_storage_linux
 
+  # fixme: This fixes #645. This can be removed after the master branch fixes it.
+  flutter_inappwebview_linux:
+    git:
+      url: https://github.com/sseu-buhzzi/flutter_inappwebview.git
+      ref: 20260215/fix-webkit-check-version
+      path: flutter_inappwebview_linux
+
 dev_dependencies:
   build_runner: ^2.1.2
   pubspec_generator: ^5.0.0


### PR DESCRIPTION
Fixes #645.

See [fix(linux): add version check for `webkit_web_view_get_theme_color`](https://github.com/sseu-buhzzi/flutter_inappwebview/commit/4c71f22252d2ad5e8dfd4e37085e0ddf6785f4fe) for changes.