### PR TITLE
style: use "OK" instead of "I see" in the input dialog

### DIFF
--- a/lib/util/noticing.dart
+++ b/lib/util/noticing.dart
@@ -179,7 +179,7 @@ class Noticing {
                           foregroundColor:
                               WidgetStateProperty.all<Color>(Colors.red))
                       : null),
-              child: PlatformText(confirmText ?? S.of(context).i_see),
+              child: PlatformText(confirmText ?? S.of(context).ok),
               onPressed: () => Navigator.pop(context, controller.text)),
         ],
       ),


### PR DESCRIPTION
It is a bit strange to answer "I see" after entering some text.