### PR TITLE
feat: support dynamic proxy updates for Dio instances

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,6 +54,7 @@ import 'package:dan_xi/page/subpage_settings.dart';
 import 'package:dan_xi/provider/settings_provider.dart';
 import 'package:dan_xi/provider/state_provider.dart';
 import 'package:dan_xi/repository/fdu/neo_login_tool.dart';
+import 'package:dan_xi/util/io/dio_utils.dart';
 import 'package:dan_xi/util/lazy_future.dart';
 import 'package:dan_xi/util/master_detail_view.dart';
 import 'package:dan_xi/util/platform_universal.dart';
@@ -106,6 +107,9 @@ Future<void> main() async {
   // Init SettingsProvider. SettingsProvider is a singleton class that stores
   // all the settings of the app.
   await SettingsProvider.getInstance().init();
+  SettingsProvider.getInstance().addListener(() {
+    DioUtils.applyProxyToAllTracked(SettingsProvider.getInstance().proxy);
+  });
 
   // Restore persisted session cookies before any network requests.
   // This must run after SettingsProvider.init() because it depends on

--- a/lib/page/forum/image_viewer.dart
+++ b/lib/page/forum/image_viewer.dart
@@ -56,8 +56,9 @@ import 'package:share_plus/share_plus.dart';
 class ImageViewerPage extends StatefulWidget {
   final Map<String, dynamic>? arguments;
   @protected
-  final Dio dio =
-      DioUtils.newDioWithProxy(BaseOptions(responseType: ResponseType.bytes));
+  final Dio dio = DioUtils.newDioWithProxy(
+    options: BaseOptions(responseType: ResponseType.bytes),
+  );
 
   static const List<String> IMAGE_SUFFIX = [
     '.jpg',

--- a/lib/repository/app/announcement_repository.dart
+++ b/lib/repository/app/announcement_repository.dart
@@ -42,7 +42,7 @@ class AnnouncementRepository {
 
   /// Get cached HTTP client with lazy initialization
   Dio get _httpClient {
-    _dio ??= DioUtils.newDioWithProxy();
+    _dio ??= DioUtils.newDioWithProxy(track: true);
     return _dio!;
   }
 

--- a/lib/repository/base_repository.dart
+++ b/lib/repository/base_repository.dart
@@ -41,7 +41,7 @@ abstract class BaseRepositoryWithDio {
   @protected
   Dio get dio {
     if (!_dios.containsKey(linkHost)) {
-      _dios[linkHost] = DioUtils.newDioWithProxy();
+      _dios[linkHost] = DioUtils.newDioWithProxy(track: true);
       _dios[linkHost]!.options = BaseOptions(
           receiveDataWhenStatusError: true,
           connectTimeout: const Duration(seconds: 2),

--- a/lib/repository/fdu/empty_classroom_repository.dart
+++ b/lib/repository/fdu/empty_classroom_repository.dart
@@ -58,9 +58,12 @@ class EmptyClassroomRepository extends BaseRepositoryWithDio {
   }
 
   /// Dio instance that does not use WebVPN proxy to check LAN connection.
-  Dio directDio = DioUtils.newDioWithProxy(BaseOptions(
+  Dio directDio = DioUtils.newDioWithProxy(
+    options: BaseOptions(
       connectTimeout: const Duration(seconds: 3),
-      receiveTimeout: const Duration(seconds: 3)));
+      receiveTimeout: const Duration(seconds: 3),
+    )
+  );
 
   static final _instance = EmptyClassroomRepository._();
 

--- a/lib/repository/fdu/neo_login_tool.dart
+++ b/lib/repository/fdu/neo_login_tool.dart
@@ -70,17 +70,20 @@ class FudanSession {
 
   static Dio get dio {
     if (_dio == null) {
-      _dio = DioUtils.newDioWithProxy(BaseOptions(
-        receiveDataWhenStatusError: true,
-        connectTimeout: const Duration(seconds: 5),
-        receiveTimeout: const Duration(seconds: 5),
-        sendTimeout: const Duration(seconds: 5),
-        // Disable Dio's built-in redirect handling as it has issues
-        // RedirectInterceptor provides proper redirect tracking
-        followRedirects: false,
-        // Allow 3xx status codes to avoid exceptions, since we handle redirects manually
-        validateStatus: (status) => status != null && status < 400,
-      ));
+      _dio = DioUtils.newDioWithProxy(
+        options: BaseOptions(
+          receiveDataWhenStatusError: true,
+          connectTimeout: const Duration(seconds: 5),
+          receiveTimeout: const Duration(seconds: 5),
+          sendTimeout: const Duration(seconds: 5),
+          // Disable Dio's built-in redirect handling as it has issues
+          // RedirectInterceptor provides proper redirect tracking
+          followRedirects: false,
+          // Allow 3xx status codes to avoid exceptions, since we handle redirects manually
+          validateStatus: (status) => status != null && status < 400,
+        ),
+        track: true,
+      );
 
       // 1. Request throttling (must be first)
       _dio!.interceptors.add(LimitedQueuedInterceptor.getInstance());

--- a/lib/util/forum/jwt_interceptor.dart
+++ b/lib/util/forum/jwt_interceptor.dart
@@ -33,7 +33,7 @@ import 'package:flutter/cupertino.dart';
 /// * [JWToken]
 /// * [ForumProvider]
 class JWTInterceptor extends QueuedInterceptor {
-  final Dio _dio = DioUtils.newDioWithProxy();
+  final Dio _dio = DioUtils.newDioWithProxy(track: true);
   final String refreshUrl;
   final Function tokenGetter;
   final Function? tokenSetter;

--- a/lib/util/io/cache_manager_with_webvpn.dart
+++ b/lib/util/io/cache_manager_with_webvpn.dart
@@ -23,7 +23,7 @@ import 'package:http/http.dart';
 
 /// [HttpFileService], but backed by dio and supports webvpn.
 class HttpFileServiceWithWebvpn extends FileService {
-  final Dio _dio = DioUtils.newDioWithProxy();
+  final Dio _dio = DioUtils.newDioWithProxy(track: true);
 
   HttpFileServiceWithWebvpn() {
     _dio.interceptors.add(WebVPNInterceptor());

--- a/lib/util/io/dio_utils.dart
+++ b/lib/util/io/dio_utils.dart
@@ -120,11 +120,38 @@ class DioUtils {
     return true;
   }
 
+  static final List<WeakReference<Dio>> _trackedDioList = [];
+
   /// Create a new [Dio] instance with the proxy set to the one in [SettingsProvider].
-  static Dio newDioWithProxy([BaseOptions? options]) {
+  ///
+  /// If [track] is true, the instance will be tracked and updated when
+  /// [applyProxyToAllTracked] is called.
+  static Dio newDioWithProxy({BaseOptions? options, bool track = false}) {
     Dio dio = Dio(options);
-    setProxy(dio, SettingsProvider.getInstance().proxy);
+    final proxy = SettingsProvider.getInstance().proxy;
+    setProxy(dio, proxy);
+    if (track) {
+      _trackedDioList.add(WeakReference(dio));
+    }
     return dio;
+  }
+
+  static String? _lastAppliedProxy = "";
+
+  /// Apply the [proxy] to all tracked [Dio] instances.
+  static void applyProxyToAllTracked(String? proxy) {
+    if (proxy == _lastAppliedProxy) {
+      return;
+    }
+    _trackedDioList.removeWhere((ref) {
+      final dio = ref.target;
+      if (dio == null) {
+        return true;
+      }
+      setProxy(dio, proxy);
+      return false;
+    });
+    _lastAppliedProxy = proxy;
   }
 
   /// Fetch with the [options], but when T is JSON-like and the response is not,

--- a/lib/util/sticker_download_manager.dart
+++ b/lib/util/sticker_download_manager.dart
@@ -46,7 +46,7 @@ Future<String> stickerFilePath(Ref ref, String stickerId) async {
   return path;
 }
 
-final _dio = DioUtils.newDioWithProxy();
+final _dio = DioUtils.newDioWithProxy(track: true);
 
 Future<void> _performDownload(RemoteSticker sticker) async {
   final response = await _dio.get<Uint8List>(

--- a/lib/util/webvpn_proxy.dart
+++ b/lib/util/webvpn_proxy.dart
@@ -122,7 +122,7 @@ class WebVPNInterceptor extends Interceptor {
         receiveTimeout: const Duration(seconds: 1),
         sendTimeout: const Duration(seconds: 1));
     // A low-timeout dio
-    Dio fastDio = DioUtils.newDioWithProxy(dioOptions);
+    Dio fastDio = DioUtils.newDioWithProxy(options: dioOptions);
 
     try {
       await fastDio.get(DIRECT_CONNECT_TEST_URL);


### PR DESCRIPTION
- Added `applyProxyToAllTracked` to `DioUtils` to update proxy settings across multiple `Dio` instances tracked with `WeakReference`.
- Registered a listener in `main.dart` to automatically apply proxy changes to all tracked instances.
- Enabled tracking for `Dio` instances at call sites.