### PR TITLE
feat: Add homepage (alternative design)

### DIFF
--- a/lib/model/forum/division.dart
+++ b/lib/model/forum/division.dart
@@ -45,4 +45,12 @@ class OTDivision {
 
   @override
   int get hashCode => division_id!;
+
+  // A special division id `-1` is used to represent the home page.
+  // This is not the most elegant solution, but the simplest. 
+  static const int HOME_PAGE_DIVISION_ID = 9999;
+
+  // Since the name and description has to be localized,
+  // we cannot specify these strings here. 
+  static OTDivision get home_page_division => OTDivision(HOME_PAGE_DIVISION_ID, null, null, null);
 }

--- a/lib/model/forum/division.dart
+++ b/lib/model/forum/division.dart
@@ -22,15 +22,17 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'division.g.dart';
 
-sealed class DivisionIdentifier {}
+sealed class DivisionIdentifier {
+  const DivisionIdentifier();
+}
 
 class Homepage extends DivisionIdentifier {
-  Homepage();
+  const Homepage();
 }
 
 class DivisionId extends DivisionIdentifier {
-  int id;
-  DivisionId(this.id);
+  final int id;
+  const DivisionId(this.id);
 }
 
 @JsonSerializable()

--- a/lib/model/forum/division.dart
+++ b/lib/model/forum/division.dart
@@ -22,6 +22,17 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'division.g.dart';
 
+sealed class DivisionIdentifier {}
+
+class Homepage extends DivisionIdentifier {
+  Homepage();
+}
+
+class DivisionId extends DivisionIdentifier {
+  int id;
+  DivisionId(this.id);
+}
+
 @JsonSerializable()
 class OTDivision {
   int? division_id;
@@ -45,8 +56,4 @@ class OTDivision {
 
   @override
   int get hashCode => division_id!;
-
-  // A special division id `9999` is used to represent the home page.
-  // This is not the most elegant solution, but the simplest. 
-  static const int HOME_PAGE_DIVISION_ID = 9999;
 }

--- a/lib/model/forum/division.dart
+++ b/lib/model/forum/division.dart
@@ -49,8 +49,4 @@ class OTDivision {
   // A special division id `-1` is used to represent the home page.
   // This is not the most elegant solution, but the simplest. 
   static const int HOME_PAGE_DIVISION_ID = 9999;
-
-  // Since the name and description has to be localized,
-  // we cannot specify these strings here. 
-  static OTDivision get home_page_division => OTDivision(HOME_PAGE_DIVISION_ID, null, null, null);
 }

--- a/lib/model/forum/division.dart
+++ b/lib/model/forum/division.dart
@@ -46,7 +46,7 @@ class OTDivision {
   @override
   int get hashCode => division_id!;
 
-  // A special division id `-1` is used to represent the home page.
+  // A special division id `9999` is used to represent the home page.
   // This is not the most elegant solution, but the simplest. 
   static const int HOME_PAGE_DIVISION_ID = 9999;
 }

--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -939,6 +939,16 @@ class BBSPostDetailState extends State<BBSPostDetail> {
             if (confirmed != true || !mounted) return;
 
             ForumProvider provider = context.read<ForumProvider>();
+
+            // We are unable to trace that a floor opened in Homepage belongs to
+            // which division originally, so we can only forbid pin/unpin operation
+            // on Homepage until the server provides such support.
+            if (provider.currentDivisionId is Homepage) {
+              Noticing.showModalNotice(context,
+                  message: "不允许从主页操作");
+              return;
+            }
+
             int divisionId = provider.currentDivision!.division_id!;
             List<int> pinned = provider.currentDivision!.pinned!
                 .map((hole) => hole.hole_id!)
@@ -953,7 +963,7 @@ class BBSPostDetailState extends State<BBSPostDetail> {
             if (result != null && result < 300) {
               // refresh the division's pinned holes
               final _ = await ForumRepository.getInstance()
-                  .loadSpecificDivision(divisionId, useCache: false);
+                  .loadSpecificDivision(DivisionId(divisionId), useCache: false);
               if (mounted) {
                 Noticing.showMaterialNotice(
                     context, S.of(context).operation_successful);

--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -943,7 +943,7 @@ class BBSPostDetailState extends State<BBSPostDetail> {
             // We are unable to trace that a floor opened in Homepage belongs to
             // which division originally, so we can only forbid pin/unpin operation
             // on Homepage until the server provides such support.
-            if (provider.currentDivisionId is Homepage) {
+            if (provider.currentDivisionId is! DivisionId) {
               Noticing.showModalNotice(context,
                   message: "不允许从主页操作");
               return;

--- a/lib/page/forum/hole_editor.dart
+++ b/lib/page/forum/hole_editor.dart
@@ -682,6 +682,15 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
           divisionList.first.division_id;
     }
 
+    int defaultChoice = widget.requireDivision ? divisionList.indexWhere(
+      (e) =>
+          e.division_id ==
+          context
+              .read<ForumProvider>()
+              .editorCache[widget.editorObject]
+              ?.divisionId,
+    ) : 0;
+
     return SingleChildScrollView(
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -695,7 +704,7 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
               enabled: true,
               wrapped: false,
               singleChoice: true,
-              defaultChoice: 0,
+              defaultChoice: defaultChoice >= 0 ? defaultChoice : 0,
               onChoice: (Tag tag, list) {
                 OTDivision division = divisionList.firstWhere(
                   (element) => element.name == tag.tagTitle,

--- a/lib/page/forum/hole_editor.dart
+++ b/lib/page/forum/hole_editor.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 import 'package:dan_xi/common/constant.dart';
 import 'package:dan_xi/common/icon_fonts.dart';
 import 'package:dan_xi/generated/l10n.dart';
+import 'package:dan_xi/model/forum/division.dart';
 import 'package:dan_xi/model/forum/tag.dart';
 import 'package:dan_xi/model/remote_sticker.dart';
 import 'package:dan_xi/page/home_page.dart';
@@ -37,6 +38,8 @@ import 'package:dan_xi/util/platform_universal.dart';
 import 'package:dan_xi/util/public_extension_methods.dart';
 import 'package:dan_xi/util/sticker_download_manager.dart';
 import 'package:dan_xi/widget/dialogs/care_dialog.dart';
+import 'package:dan_xi/widget/forum/tag_selector/selector.dart';
+import 'package:dan_xi/widget/forum/tag_selector/tag.dart';
 import 'package:dan_xi/widget/libraries/error_page_widget.dart';
 import 'package:dan_xi/widget/libraries/image_picker_proxy.dart';
 import 'package:dan_xi/widget/libraries/linkify_x.dart';
@@ -55,8 +58,8 @@ import 'package:provider/provider.dart';
 
 enum OTEditorType { DIALOG, PAGE }
 
-typedef PostInterceptor = Future<bool> Function(
-    BuildContext context, PostEditorText? text);
+typedef PostInterceptor =
+    Future<bool> Function(BuildContext context, PostEditorText? text);
 
 extension PostInterceptorEx on PostInterceptor {
   PostInterceptor mergeWith(PostInterceptor? interceptor) {
@@ -76,38 +79,60 @@ final PostInterceptor _kStopWordInterceptor = (context, text) async {
   var stopWordList = await Constant.stopWords;
   stopWordList = stopWordList.map((e) => e.trim().toLowerCase()).toList();
   try {
-    var checkedStopWord = stopWordList.firstWhere((element) =>
-        element.isNotEmpty && (regularText?.contains(element) ?? false));
+    var checkedStopWord = stopWordList.firstWhere(
+      (element) =>
+          element.isNotEmpty && (regularText?.contains(element) ?? false),
+    );
     return await Noticing.showConfirmationDialog(
-            context, S.of(context).has_stop_words(checkedStopWord.trim()),
-            title: S.of(context).has_stop_words_title,
-            confirmText: S.of(context).continue_sending,
-            isConfirmDestructive: true) ??
+          context,
+          S.of(context).has_stop_words(checkedStopWord.trim()),
+          title: S.of(context).has_stop_words_title,
+          confirmText: S.of(context).continue_sending,
+          isConfirmDestructive: true,
+        ) ??
         false;
   } catch (_) {}
   return true;
 };
 
 class OTEditor {
-  static Future<bool> createNewPost(BuildContext context, int divisionId,
-      {OTEditorType? editorType, PostInterceptor? interceptor}) async {
+  static Future<bool> createNewPost(
+    BuildContext context,
+    int divisionId, {
+    OTEditorType? editorType,
+    PostInterceptor? interceptor,
+  }) async {
     final object = EditorObject(0, EditorObjectType.NEW_POST);
+    final requireDivision = divisionId == OTDivision.HOME_PAGE_DIVISION_ID;
     final PostEditorText? content = await _showEditor(
-        context, S.of(context).new_post,
-        allowTags: true,
-        editorType: editorType,
-        object: object,
-        interceptor: _kStopWordInterceptor.mergeWith(interceptor));
+      context,
+      S.of(context).new_post,
+      allowTags: true,
+      editorType: editorType,
+      object: object,
+      // If the editor is called from homepage, then we have the user select a division here in editor.
+      requireDivision: requireDivision,
+      interceptor: _kStopWordInterceptor.mergeWith(interceptor),
+    );
 
     if (content?.text == null) {
       return false;
     }
 
+    if (requireDivision && content?.divisionId != null) {
+      divisionId = content!.divisionId!;
+    }
+
     ProgressFuture progressDialog = showProgressDialog(
-        loadingText: S.of(context).posting, context: context);
+      loadingText: S.of(context).posting,
+      context: context,
+    );
     try {
-      await ForumRepository.getInstance()
-          .newHole(divisionId, content!.text, tags: content.tags);
+      await ForumRepository.getInstance().newHole(
+        divisionId,
+        content!.text,
+        tags: content.tags,
+      );
     } catch (e, st) {
       Noticing.showErrorDialog(context, e, trace: st);
       return false;
@@ -119,24 +144,30 @@ class OTEditor {
   }
 
   static Future<bool> createNewReply(
-      BuildContext context, int? discussionId, int? floorId,
-      {OTEditorType? editorType, PostInterceptor? interceptor}) async {
+    BuildContext context,
+    int? discussionId,
+    int? floorId, {
+    OTEditorType? editorType,
+    PostInterceptor? interceptor,
+  }) async {
     final object = (floorId == null
         ? EditorObject(discussionId, EditorObjectType.REPLY_TO_HOLE)
         : EditorObject(floorId, EditorObjectType.REPLY_TO_FLOOR));
     final String? content = (await _showEditor(
-            context,
-            floorId == null
-                ? S.of(context).reply_to(discussionId ?? "?")
-                : S.of(context).reply_to_floor(floorId),
-            editorType: editorType,
-            object: object,
-            placeholder: floorId == null ? "" : "##$floorId\n",
-            interceptor: _kStopWordInterceptor.mergeWith(interceptor)))
-        ?.text;
+      context,
+      floorId == null
+          ? S.of(context).reply_to(discussionId ?? "?")
+          : S.of(context).reply_to_floor(floorId),
+      editorType: editorType,
+      object: object,
+      placeholder: floorId == null ? "" : "##$floorId\n",
+      interceptor: _kStopWordInterceptor.mergeWith(interceptor),
+    ))?.text;
     if (content == null || content.trim() == "") return false;
     ProgressFuture progressDialog = showProgressDialog(
-        loadingText: S.of(context).posting, context: context);
+      loadingText: S.of(context).posting,
+      context: context,
+    );
     try {
       await ForumRepository.getInstance().newFloor(discussionId, content);
     } catch (e, st) {
@@ -149,28 +180,39 @@ class OTEditor {
     return true;
   }
 
-  static Future<bool> modifyReply(BuildContext context, int? discussionId,
-      int? floorId, String? originalContent,
-      {OTEditorType? editorType, PostInterceptor? interceptor}) async {
+  static Future<bool> modifyReply(
+    BuildContext context,
+    int? discussionId,
+    int? floorId,
+    String? originalContent, {
+    OTEditorType? editorType,
+    PostInterceptor? interceptor,
+  }) async {
     final object = EditorObject(floorId, EditorObjectType.MODIFY_FLOOR);
     final String? content = (await _showEditor(
-            context,
-            floorId == null
-                ? S.of(context).modify_to(discussionId ?? "?")
-                : S.of(context).modify_to_floor(floorId),
-            editorType: editorType,
-            object: object,
-            placeholder: originalContent ?? "",
-            interceptor: _kStopWordInterceptor.mergeWith(interceptor)))
-        ?.text;
+      context,
+      floorId == null
+          ? S.of(context).modify_to(discussionId ?? "?")
+          : S.of(context).modify_to_floor(floorId),
+      editorType: editorType,
+      object: object,
+      placeholder: originalContent ?? "",
+      interceptor: _kStopWordInterceptor.mergeWith(interceptor),
+    ))?.text;
     if (content == null || content.trim().isEmpty) return false;
     ProgressFuture progressDialog = showProgressDialog(
-        loadingText: S.of(context).posting, context: context);
+      loadingText: S.of(context).posting,
+      context: context,
+    );
     try {
       await ForumRepository.getInstance().modifyFloor(content, floorId);
     } catch (e, st) {
-      Noticing.showErrorDialog(context, e,
-          trace: st, title: S.of(context).reply_failed);
+      Noticing.showErrorDialog(
+        context,
+        e,
+        trace: st,
+        title: S.of(context).reply_failed,
+      );
       return false;
     } finally {
       progressDialog.dismiss(showAnim: false);
@@ -181,17 +223,25 @@ class OTEditor {
 
   static Future<bool> reportPost(BuildContext context, int? floorId) async {
     final String? content = (await Noticing.showInputDialog(
-        context, S.of(context).reason_report_post(floorId ?? "?"),
-        isConfirmDestructive: true));
+      context,
+      S.of(context).reason_report_post(floorId ?? "?"),
+      isConfirmDestructive: true,
+    ));
     if (content == null || content.trim() == "") return false;
 
-    ProgressFuture progressDialog =
-        showProgressDialog(loadingText: S.of(context).report, context: context);
+    ProgressFuture progressDialog = showProgressDialog(
+      loadingText: S.of(context).report,
+      context: context,
+    );
     try {
       await ForumRepository.getInstance().reportPost(floorId, content);
     } catch (error, st) {
-      Noticing.showErrorDialog(context, error,
-          trace: st, title: S.of(context).report_failed);
+      Noticing.showErrorDialog(
+        context,
+        error,
+        trace: st,
+        title: S.of(context).report_failed,
+      );
       return false;
     } finally {
       progressDialog.dismiss(showAnim: false);
@@ -199,13 +249,17 @@ class OTEditor {
     return true;
   }
 
-  static Future<PostEditorText?> _showEditor(BuildContext context, String title,
-      {bool allowTags = false,
-      required OTEditorType? editorType,
-      required EditorObject object,
-      String placeholder = "",
-      bool hasTip = true,
-      PostInterceptor? interceptor}) async {
+  static Future<PostEditorText?> _showEditor(
+    BuildContext context,
+    String title, {
+    bool allowTags = false,
+    required OTEditorType? editorType,
+    required EditorObject object,
+    String placeholder = "",
+    bool hasTip = true,
+    bool requireDivision = false,
+    PostInterceptor? interceptor,
+  }) async {
     final String randomTip = await Constant.randomForumTip;
 
     switch (editorType ?? OTEditorType.PAGE) {
@@ -215,84 +269,99 @@ class OTEditor {
               PostEditorText.newInstance(withText: placeholder);
         }
         final textController = TextEditingController(
-            text: context.read<ForumProvider>().editorCache[object]!.text);
-        textController.addListener(() => context
-            .read<ForumProvider>()
-            .editorCache[object]!
-            .text = textController.text);
+          text: context.read<ForumProvider>().editorCache[object]!.text,
+        );
+        textController.addListener(
+          () => context.read<ForumProvider>().editorCache[object]!.text =
+              textController.text,
+        );
         final value = await showPlatformDialog<PostEditorText>(
-            barrierDismissible: false,
-            context: context,
-            builder: (BuildContext context) => PlatformAlertDialog(
-                  title: Text(title),
-                  content: BBSEditorWidget(
-                    controller: textController,
-                    allowTags: allowTags,
-                    editorObject: object,
-                    tip: hasTip ? randomTip : null,
-                  ),
-                  actions: [
-                    PlatformDialogAction(
-                        child: Text(S.of(context).cancel),
-                        onPressed: () {
-                          context
-                              .read<ForumProvider>()
-                              .editorCache[object]!
-                              .text = textController.text;
-                          Navigator.of(context).pop<PostEditorText>(null);
-                        }),
-                    /*PlatformDialogAction(
+          barrierDismissible: false,
+          context: context,
+          builder: (BuildContext context) => PlatformAlertDialog(
+            title: Text(title),
+            content: BBSEditorWidget(
+              controller: textController,
+              allowTags: allowTags,
+              editorObject: object,
+              requireDivision: requireDivision,
+              tip: hasTip ? randomTip : null,
+            ),
+            actions: [
+              PlatformDialogAction(
+                child: Text(S.of(context).cancel),
+                onPressed: () {
+                  context.read<ForumProvider>().editorCache[object]!.text =
+                      textController.text;
+                  Navigator.of(context).pop<PostEditorText>(null);
+                },
+              ),
+              /*PlatformDialogAction(
                         child: Text(S.of(context).add_image),
                         onPressed: () => uploadImage(context, textController)),*/
-                    PlatformDialogAction(
-                        child: Text(S.of(context).submit),
-                        onPressed: () async {
-                          Navigator.of(context).pop<PostEditorText>(
-                              PostEditorText(
-                                  textController.text,
-                                  context
-                                      .read<ForumProvider>()
-                                      .editorCache[object]!
-                                      .tags));
-                        }),
-                  ],
-                ));
+              PlatformDialogAction(
+                child: Text(S.of(context).submit),
+                onPressed: () async {
+                  Navigator.of(context).pop<PostEditorText>(
+                    PostEditorText(
+                      textController.text,
+                      context.read<ForumProvider>().editorCache[object]!.tags,
+                      divisionId: context
+                          .read<ForumProvider>()
+                          .editorCache[object]!
+                          .divisionId,
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        );
         textController.dispose();
         return value;
       case OTEditorType.PAGE:
         // Receive the value with **dynamic** variable to prevent automatic type inference
         final dynamic result = await smartNavigatorPush(
-            context, '/bbs/fullScreenEditor',
-            arguments: {
-              "title": title,
-              "tags": allowTags,
-              'object': object,
-              'placeholder': placeholder,
-              'tip': randomTip,
-              'interceptor': interceptor
-            });
+          context,
+          '/bbs/fullScreenEditor',
+          arguments: {
+            "title": title,
+            "tags": allowTags,
+            'object': object,
+            'placeholder': placeholder,
+            'tip': randomTip,
+            'requireDivision': requireDivision,
+            'interceptor': interceptor,
+          },
+        );
         return result;
     }
   }
 
   @protected
   static Future<void> uploadImage(
-      BuildContext context, TextEditingController controller) async {
+    BuildContext context,
+    TextEditingController controller,
+  ) async {
     final ImagePickerProxy picker = ImagePickerProxy.createPicker();
     final String? file = await picker.pickImage();
     if (file == null) return;
 
     ProgressFuture progressDialog = showProgressDialog(
-        loadingText: S.of(context).uploading_image, context: context);
+      loadingText: S.of(context).uploading_image,
+      context: context,
+    );
     try {
       String? url = await ForumRepository.getInstance().uploadImage(File(file));
       if (url != null) controller.text += "![]($url)";
       // "showAnim: true" makes it crash. Don't know the reason.
       progressDialog.dismiss(showAnim: false);
     } catch (error) {
-      Noticing.showNotice(context,
-          ErrorPageWidget.generateUserFriendlyDescription(S.of(context), error),
-          title: S.of(context).uploading_image_failed);
+      Noticing.showNotice(
+        context,
+        ErrorPageWidget.generateUserFriendlyDescription(S.of(context), error),
+        title: S.of(context).uploading_image_failed,
+      );
     } finally {
       progressDialog.dismiss(showAnim: false);
     }
@@ -304,15 +373,18 @@ class BBSEditorWidget extends StatefulWidget {
   final EditorObject? editorObject;
   final bool? allowTags;
   final bool fullscreen;
+  final bool requireDivision;
   final String? tip;
 
-  const BBSEditorWidget(
-      {super.key,
-      required this.controller,
-      this.allowTags,
-      this.editorObject,
-      this.fullscreen = false,
-      this.tip});
+  const BBSEditorWidget({
+    super.key,
+    required this.controller,
+    this.allowTags,
+    this.editorObject,
+    this.fullscreen = false,
+    this.requireDivision = false,
+    this.tip,
+  });
 
   @override
   BBSEditorWidgetState createState() => BBSEditorWidgetState();
@@ -360,90 +432,100 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
 
   Future<T?> _buildStickersSheet<T>(BuildContext context) {
     return showPlatformModalSheet(
-        context: context,
-        builder: (BuildContext context) {
-          final Widget body = SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(10.0),
-              child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ListTile(
-                        leading: const Icon(Icons.emoji_emotions),
-                        title: Text(S.of(context).sticker)),
-                    Expanded(
-                      child: HookConsumer(builder:
-                          (BuildContext context, WidgetRef ref, Widget? child) {
-                        final stickers = ref.watch(availableStickersProvider);
-                        return stickers.when(
-                          loading: () => const Center(
-                            child: PlatformCircularProgressIndicator(),
-                          ),
-                          error: (error, stackTrace) => Center(
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Icon(
-                                  Icons.error_outline,
-                                  size: 48,
-                                  color: Theme.of(context).colorScheme.error,
+      context: context,
+      builder: (BuildContext context) {
+        final Widget body = SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  leading: const Icon(Icons.emoji_emotions),
+                  title: Text(S.of(context).sticker),
+                ),
+                Expanded(
+                  child: HookConsumer(
+                    builder: (BuildContext context, WidgetRef ref, Widget? child) {
+                      final stickers = ref.watch(availableStickersProvider);
+                      return stickers.when(
+                        loading: () => const Center(
+                          child: PlatformCircularProgressIndicator(),
+                        ),
+                        error: (error, stackTrace) => Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.error_outline,
+                                size: 48,
+                                color: Theme.of(context).colorScheme.error,
+                              ),
+                              const SizedBox(height: 16),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16.0,
                                 ),
-                                const SizedBox(height: 16),
-                                Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 16.0),
-                                  child: Text(
-                                    ErrorPageWidget
-                                        .generateUserFriendlyDescription(
-                                            S.of(context), error),
-                                    style: TextStyle(
-                                      color:
-                                          Theme.of(context).colorScheme.error,
-                                      fontSize: 16,
-                                    ),
-                                    textAlign: TextAlign.center,
+                                child: Text(
+                                  ErrorPageWidget.generateUserFriendlyDescription(
+                                    S.of(context),
+                                    error,
                                   ),
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.error,
+                                    fontSize: 16,
+                                  ),
+                                  textAlign: TextAlign.center,
                                 ),
-                                const SizedBox(height: 8),
-                                TextButton(
-                                  onPressed: () =>
-                                      ref.invalidate(availableStickersProvider),
-                                  child: Text(S.of(context).retry),
-                                ),
-                                TextButton(
-                                  onPressed: () {
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: Text(S.of(context).cancel),
-                                ),
-                              ],
-                            ),
+                              ),
+                              const SizedBox(height: 8),
+                              TextButton(
+                                onPressed: () =>
+                                    ref.invalidate(availableStickersProvider),
+                                child: Text(S.of(context).retry),
+                              ),
+                              TextButton(
+                                onPressed: () {
+                                  Navigator.of(context).pop();
+                                },
+                                child: Text(S.of(context).cancel),
+                              ),
+                            ],
                           ),
-                          data: (stickers) =>
-                              _buildStickerGrid(context, ref, stickers),
-                        );
-                      }),
-                    ),
-                  ]),
+                        ),
+                        data: (stickers) =>
+                            _buildStickerGrid(context, ref, stickers),
+                      );
+                    },
+                  ),
+                ),
+              ],
             ),
-          );
-          return PlatformX.isCupertino(context)
-              ? ConstrainedBox(
-                  constraints: BoxConstraints(
-                      maxHeight: 0.66 * MediaQuery.of(context).size.height),
-                  child: Card(child: body))
-              : body;
-        });
+          ),
+        );
+        return PlatformX.isCupertino(context)
+            ? ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: 0.66 * MediaQuery.of(context).size.height,
+                ),
+                child: Card(child: body),
+              )
+            : body;
+      },
+    );
   }
 
   Widget _buildStickerGrid(
-      BuildContext context, WidgetRef ref, List<RemoteSticker> stickers) {
+    BuildContext context,
+    WidgetRef ref,
+    List<RemoteSticker> stickers,
+  ) {
     final allStickerIds = stickers.map((e) => e.id).toList();
 
     final stickerSheetColumns = 5;
-    final stickerSheetRows =
-        (allStickerIds.length / stickerSheetColumns).ceil();
+    final stickerSheetRows = (allStickerIds.length / stickerSheetColumns)
+        .ceil();
 
     return SingleChildScrollView(
       scrollDirection: Axis.vertical,
@@ -459,63 +541,63 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
             return Container(
               alignment: Alignment.center,
               child: InkWell(
-                  onTap: () {
-                    var cursorPosition =
-                        widget.controller.selection.base.offset;
-                    cursorPosition = cursorPosition == -1
-                        ? widget.controller.text.length
-                        : cursorPosition;
-                    widget.controller.text =
-                        "${widget.controller.text.substring(0, cursorPosition)}![]($stickerId)${widget.controller.text.substring(cursorPosition)}";
-                    Navigator.of(context).pop();
-                  },
-                  child: sticker.when(
-                    loading: () => SizedBox(
-                      width: 60,
-                      height: 60,
-                      child: const Center(
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
+                onTap: () {
+                  var cursorPosition = widget.controller.selection.base.offset;
+                  cursorPosition = cursorPosition == -1
+                      ? widget.controller.text.length
+                      : cursorPosition;
+                  widget.controller.text =
+                      "${widget.controller.text.substring(0, cursorPosition)}![]($stickerId)${widget.controller.text.substring(cursorPosition)}";
+                  Navigator.of(context).pop();
+                },
+                child: sticker.when(
+                  loading: () => SizedBox(
+                    width: 60,
+                    height: 60,
+                    child: const Center(
+                      child: CircularProgressIndicator(strokeWidth: 2),
                     ),
-                    error: (error, stackTrace) => Container(
-                      width: 60,
-                      height: 60,
-                      decoration: BoxDecoration(
-                        color: Colors.grey[200],
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      child: InkWell(
-                        onTap: () =>
-                            ref.invalidate(stickerFilePathProvider(stickerId)),
-                        child: Center(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                Icons.refresh,
+                  ),
+                  error: (error, stackTrace) => Container(
+                    width: 60,
+                    height: 60,
+                    decoration: BoxDecoration(
+                      color: Colors.grey[200],
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: InkWell(
+                      onTap: () =>
+                          ref.invalidate(stickerFilePathProvider(stickerId)),
+                      child: Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.refresh,
+                              color: Theme.of(context).colorScheme.error,
+                              size: 20,
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              S.of(context).retry,
+                              style: TextStyle(
                                 color: Theme.of(context).colorScheme.error,
-                                size: 20,
+                                fontSize: 10,
                               ),
-                              const SizedBox(height: 2),
-                              Text(
-                                S.of(context).retry,
-                                style: TextStyle(
-                                  color: Theme.of(context).colorScheme.error,
-                                  fontSize: 10,
-                                ),
-                              ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
                       ),
                     ),
-                    data: (filePath) => Image.file(
-                      File(filePath),
-                      width: 60,
-                      height: 60,
-                      fit: BoxFit.contain,
-                    ),
-                  )),
+                  ),
+                  data: (filePath) => Image.file(
+                    File(filePath),
+                    width: 60,
+                    height: 60,
+                    fit: BoxFit.contain,
+                  ),
+                ),
+              ),
             );
           }).toList(),
         ),
@@ -523,46 +605,53 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
     );
   }
 
-  Widget _buildIntroButton(BuildContext context, IconData iconData,
-          String title, String description) =>
-      PlatformIconButton(
-          icon: Icon(iconData, color: Theme.of(context).colorScheme.secondary),
-          onPressed: () => showPlatformModalSheet(
-              context: context,
-              builder: (BuildContext context) {
-                final Widget body = SafeArea(
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          ListTile(leading: Icon(iconData), title: Text(title)),
-                          const Divider(),
-                          Padding(
-                              padding: const EdgeInsets.all(16.0),
-                              child: LinkifyX(
-                                text: description,
-                                onOpen: (element) =>
-                                    BrowserUtil.openUrl(element.url, context),
-                              )),
-                        ]),
+  Widget _buildIntroButton(
+    BuildContext context,
+    IconData iconData,
+    String title,
+    String description,
+  ) => PlatformIconButton(
+    icon: Icon(iconData, color: Theme.of(context).colorScheme.secondary),
+    onPressed: () => showPlatformModalSheet(
+      context: context,
+      builder: (BuildContext context) {
+        final Widget body = SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(leading: Icon(iconData), title: Text(title)),
+                const Divider(),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: LinkifyX(
+                    text: description,
+                    onOpen: (element) =>
+                        BrowserUtil.openUrl(element.url, context),
                   ),
-                );
-                return PlatformX.isCupertino(context)
-                    ? Card(child: body)
-                    : body;
-              }));
+                ),
+              ],
+            ),
+          ),
+        );
+        return PlatformX.isCupertino(context) ? Card(child: body) : body;
+      },
+    ),
+  );
 
   @override
   Widget build(BuildContext context) {
     final Widget textField = PlatformTextField(
       hintText: widget.tip,
       material: (_, __) => MaterialTextFieldData(
-          decoration: widget.fullscreen
-              ? const InputDecoration(border: InputBorder.none)
-              : const InputDecoration(
-                  border: OutlineInputBorder(gapPadding: 2.0))),
+        decoration: widget.fullscreen
+            ? const InputDecoration(border: InputBorder.none)
+            : const InputDecoration(
+                border: OutlineInputBorder(gapPadding: 2.0),
+              ),
+      ),
       controller: widget.controller,
       keyboardType: TextInputType.multiline,
       maxLines: widget.fullscreen ? null : 5,
@@ -570,139 +659,200 @@ class BBSEditorWidgetState extends State<BBSEditorWidget> {
       autofocus: true,
       textAlignVertical: TextAlignVertical.top,
     );
+
     if (widget.fullscreen) {
       return textField;
     }
+
+    List<OTDivision> divisionList = widget.requireDivision
+        ? context.select<ForumProvider, List<OTDivision>>(
+            (value) => value.divisionCache,
+          )
+        : [];
+    if (divisionList.isNotEmpty &&
+        context
+                .read<ForumProvider>()
+                .editorCache[widget.editorObject]!
+                .divisionId ==
+            null) {
+      context
+              .read<ForumProvider>()
+              .editorCache[widget.editorObject]!
+              .divisionId =
+          divisionList.first.division_id;
+    }
+
     return SingleChildScrollView(
       child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (widget.allowTags!)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: OTTagSelector(
-                    key: _tagSelectorKey,
-                    initialTags: context
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.requireDivision)
+            TagContainer(
+              fillRandomColor: false,
+              fixedColor: Theme.of(context).colorScheme.primary,
+              fontSize: 12,
+              enabled: true,
+              wrapped: false,
+              singleChoice: true,
+              defaultChoice: 0,
+              onChoice: (Tag tag, list) {
+                OTDivision division = divisionList.firstWhere(
+                  (element) => element.name == tag.tagTitle,
+                );
+                context
                         .read<ForumProvider>()
                         .editorCache[widget.editorObject]!
-                        .tags),
+                        .divisionId =
+                    division.division_id;
+              },
+              tagList: divisionList
+                  .map((e) => Tag(e.name, null, checkedIcon: null))
+                  .toList(),
+            ),
+          if (widget.allowTags!)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: OTTagSelector(
+                key: _tagSelectorKey,
+                initialTags: context
+                    .read<ForumProvider>()
+                    .editorCache[widget.editorObject]!
+                    .tags,
               ),
-            if (widget.allowTags! &&
-                SettingsProvider.getInstance().tagSuggestionAvailable) ...[
-              Padding(
-                padding: const EdgeInsets.only(top: 4, left: 8, right: 8),
-                child: Row(
-                  children: [
-                    Text(S.of(context).recommended_tags),
-                    ScaleTransform(
-                      scale: 0.75,
-                      child: PlatformIconButton(
-                        padding: const EdgeInsets.only(left: 0),
-                        icon: const Icon(CupertinoIcons.info_circle),
-                        onPressed: () {
-                          Noticing.showModalNotice(context,
-                              message:
-                                  S.of(context).recommended_tags_description,
-                              title: S.of(context).recommended_tags);
-                        },
-                      ),
-                    ),
-                    Selector<SettingsProvider, bool>(
-                        builder: (_, bool value, __) {
-                          if (!value) {
-                            return PlatformTextButton(
-                              padding: EdgeInsets.zero,
-                              child: Text(S.of(context).enable),
-                              onPressed: () async {
-                                if (await Noticing.showConfirmationDialog(
-                                        context,
-                                        S
-                                            .of(context)
-                                            .recommended_tags_description,
-                                        title:
-                                            S.of(context).recommended_tags) ==
-                                    true) {
-                                  SettingsProvider.getInstance()
-                                      .isTagSuggestionEnabled = true;
-                                }
-                              },
-                            );
-                          }
-                          return const SizedBox.shrink();
-                        },
-                        selector: (_, model) => model.isTagSuggestionEnabled),
-                  ],
-                ),
-              ),
-              Selector<SettingsProvider, bool>(
-                  builder: (_, bool value, __) {
-                    if (value) {
-                      return Padding(
-                        padding:
-                            const EdgeInsets.only(bottom: 4, left: 4, right: 4),
-                        child: ValueListenableBuilder<TextEditingValue>(
-                          builder: (context, value, child) =>
-                              TagSuggestionWidget(
-                            content: value.text,
-                            tagSelectorKey: _tagSelectorKey,
-                          ),
-                          valueListenable: widget.controller,
-                        ),
-                      );
-                    }
-                    return const SizedBox.shrink();
-                  },
-                  selector: (_, model) => model.isTagSuggestionEnabled),
-            ],
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
+            ),
+          if (widget.allowTags! &&
+              SettingsProvider.getInstance().tagSuggestionAvailable) ...[
+            Padding(
+              padding: const EdgeInsets.only(top: 4, left: 8, right: 8),
               child: Row(
                 children: [
-                  _buildIntroButton(
-                      context,
-                      IconFont.markdown,
-                      S.of(context).markdown_enabled,
-                      S.of(context).markdown_description),
-                  _buildIntroButton(
-                      context,
-                      IconFont.tex,
-                      S.of(context).latex_enabled,
-                      S.of(context).latex_description),
-                  PlatformTextButton(
-                    child: Text(S.of(context).community_convention),
-                    onPressed: () => BrowserUtil.openUrl(
-                        "https://www.fduhole.com/doc", context),
+                  Text(S.of(context).recommended_tags),
+                  ScaleTransform(
+                    scale: 0.75,
+                    child: PlatformIconButton(
+                      padding: const EdgeInsets.only(left: 0),
+                      icon: const Icon(CupertinoIcons.info_circle),
+                      onPressed: () {
+                        Noticing.showModalNotice(
+                          context,
+                          message: S.of(context).recommended_tags_description,
+                          title: S.of(context).recommended_tags,
+                        );
+                      },
+                    ),
                   ),
-                  PlatformTextButton(
-                    child: Text(S.of(context).sticker),
-                    onPressed: () => _buildStickersSheet(context),
+                  Selector<SettingsProvider, bool>(
+                    builder: (_, bool value, __) {
+                      if (!value) {
+                        return PlatformTextButton(
+                          padding: EdgeInsets.zero,
+                          child: Text(S.of(context).enable),
+                          onPressed: () async {
+                            if (await Noticing.showConfirmationDialog(
+                                  context,
+                                  S.of(context).recommended_tags_description,
+                                  title: S.of(context).recommended_tags,
+                                ) ==
+                                true) {
+                              SettingsProvider.getInstance()
+                                      .isTagSuggestionEnabled =
+                                  true;
+                            }
+                          },
+                        );
+                      }
+                      return const SizedBox.shrink();
+                    },
+                    selector: (_, model) => model.isTagSuggestionEnabled,
                   ),
                 ],
               ),
             ),
-            textField,
-            const Divider(),
-            Text(S.of(context).preview,
-                style: TextStyle(color: Theme.of(context).hintColor)),
-            Padding(
-              padding: const EdgeInsets.only(top: 4.0),
-              child: ValueListenableBuilder<TextEditingValue>(
-                builder: (context, value, child) => smartRender(
-                    context, value.text, false,
-                    preview: true,
-                    onLongPressImage: (url) => _deleteImageFromText(url)),
-                valueListenable: widget.controller,
-              ),
+            Selector<SettingsProvider, bool>(
+              builder: (_, bool value, __) {
+                if (value) {
+                  return Padding(
+                    padding: const EdgeInsets.only(
+                      bottom: 4,
+                      left: 4,
+                      right: 4,
+                    ),
+                    child: ValueListenableBuilder<TextEditingValue>(
+                      builder: (context, value, child) => TagSuggestionWidget(
+                        content: value.text,
+                        tagSelectorKey: _tagSelectorKey,
+                      ),
+                      valueListenable: widget.controller,
+                    ),
+                  );
+                }
+                return const SizedBox.shrink();
+              },
+              selector: (_, model) => model.isTagSuggestionEnabled,
             ),
-          ]),
+          ],
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                _buildIntroButton(
+                  context,
+                  IconFont.markdown,
+                  S.of(context).markdown_enabled,
+                  S.of(context).markdown_description,
+                ),
+                _buildIntroButton(
+                  context,
+                  IconFont.tex,
+                  S.of(context).latex_enabled,
+                  S.of(context).latex_description,
+                ),
+                PlatformTextButton(
+                  child: Text(S.of(context).community_convention),
+                  onPressed: () => BrowserUtil.openUrl(
+                    "https://www.fduhole.com/doc",
+                    context,
+                  ),
+                ),
+                PlatformTextButton(
+                  child: Text(S.of(context).sticker),
+                  onPressed: () => _buildStickersSheet(context),
+                ),
+              ],
+            ),
+          ),
+          textField,
+          const Divider(),
+          Text(
+            S.of(context).preview,
+            style: TextStyle(color: Theme.of(context).hintColor),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 4.0),
+            child: ValueListenableBuilder<TextEditingValue>(
+              builder: (context, value, child) => smartRender(
+                context,
+                value.text,
+                false,
+                preview: true,
+                onLongPressImage: (url) => _deleteImageFromText(url),
+              ),
+              valueListenable: widget.controller,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
 
 class TagSuggestionWidget extends StatefulWidget {
-  const TagSuggestionWidget(
-      {super.key, required this.content, required this.tagSelectorKey});
+  const TagSuggestionWidget({
+    super.key,
+    required this.content,
+    required this.tagSelectorKey,
+  });
 
   final String content;
   final GlobalKey<OTTagSelectorState> tagSelectorKey;
@@ -749,29 +899,42 @@ class TagSuggestionWidgetState extends State<TagSuggestionWidget> {
     return ConstrainedBox(
       constraints: const BoxConstraints(minHeight: 32),
       child: Wrap(
-          children: _suggestions
-                  ?.map((e) => Padding(
-                        padding: const EdgeInsets.symmetric(
-                            vertical: 4, horizontal: 4),
-                        child: RoundChip(
-                            label: e,
-                            color: (e.hashColor()),
-                            onTap: () {
-                              widget.tagSelectorKey.currentState?.setState(() {
-                                if (widget.tagSelectorKey.currentState?.widget
-                                        .initialTags
-                                        .any((element) => element.name == e) ==
-                                    true) {
-                                } else {
-                                  widget.tagSelectorKey.currentState!.widget
-                                      .initialTags
-                                      .add(OTTag(0, 0, e));
-                                }
-                              });
-                            }),
-                      ))
-                  .toList() ??
-              []),
+        children:
+            _suggestions
+                ?.map(
+                  (e) => Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 4,
+                      horizontal: 4,
+                    ),
+                    child: RoundChip(
+                      label: e,
+                      color: (e.hashColor()),
+                      onTap: () {
+                        widget.tagSelectorKey.currentState?.setState(() {
+                          if (widget
+                                  .tagSelectorKey
+                                  .currentState
+                                  ?.widget
+                                  .initialTags
+                                  .any((element) => element.name == e) ==
+                              true) {
+                          } else {
+                            widget
+                                .tagSelectorKey
+                                .currentState!
+                                .widget
+                                .initialTags
+                                .add(OTTag(0, 0, e));
+                          }
+                        });
+                      },
+                    ),
+                  ),
+                )
+                .toList() ??
+            [],
+      ),
     );
   }
 }
@@ -779,8 +942,9 @@ class TagSuggestionWidgetState extends State<TagSuggestionWidget> {
 class PostEditorText {
   String? text;
   List<OTTag> tags = List<OTTag>.empty(growable: true);
+  int? divisionId;
 
-  PostEditorText(this.text, this.tags);
+  PostEditorText(this.text, this.tags, {this.divisionId});
 
   PostEditorText.newInstance({withText = ''}) {
     text = withText;
@@ -812,6 +976,7 @@ class BBSEditorPageState extends State<BBSEditorPage> {
 
   bool _isFullscreen = false;
   bool? _supportTags;
+  bool _requireDivision = false;
   bool _confirmCareWords = false;
 
   String? _tip;
@@ -846,9 +1011,12 @@ class BBSEditorPageState extends State<BBSEditorPage> {
         widget.arguments!['title'] ?? S.of(context).forum_post_enter_content;
     _object = widget.arguments!['object'];
     _placeholder = widget.arguments!['placeholder'];
+    _requireDivision = widget.arguments!['requireDivision'] ?? false;
     if (context.read<ForumProvider>().editorCache.containsKey(_object)) {
-      _controller.text =
-          context.read<ForumProvider>().editorCache[_object]!.text!;
+      _controller.text = context
+          .read<ForumProvider>()
+          .editorCache[_object]!
+          .text!;
     } else {
       context.read<ForumProvider>().editorCache[_object] =
           PostEditorText.newInstance(withText: _placeholder);
@@ -861,11 +1029,11 @@ class BBSEditorPageState extends State<BBSEditorPage> {
   Widget build(BuildContext context) {
     Icon fullScreenIcon = _isFullscreen
         ? (PlatformX.isMaterial(context)
-            ? const Icon(Icons.close_fullscreen)
-            : const Icon(CupertinoIcons.fullscreen_exit))
+              ? const Icon(Icons.close_fullscreen)
+              : const Icon(CupertinoIcons.fullscreen_exit))
         : (PlatformX.isMaterial(context)
-            ? const Icon(Icons.fullscreen)
-            : const Icon(CupertinoIcons.fullscreen));
+              ? const Icon(Icons.fullscreen)
+              : const Icon(CupertinoIcons.fullscreen));
     return PlatformScaffold(
       iosContentBottomPadding: false,
       iosContentPadding: false,
@@ -874,15 +1042,17 @@ class BBSEditorPageState extends State<BBSEditorPage> {
         title: Text(_title),
         trailingActions: [
           PlatformIconButton(
-              padding: EdgeInsets.zero,
-              icon: fullScreenIcon,
-              onPressed: () => setState(() => _isFullscreen = !_isFullscreen)),
+            padding: EdgeInsets.zero,
+            icon: fullScreenIcon,
+            onPressed: () => setState(() => _isFullscreen = !_isFullscreen),
+          ),
           PlatformIconButton(
-              padding: EdgeInsets.zero,
-              icon: PlatformX.isMaterial(context)
-                  ? const Icon(Icons.photo)
-                  : const Icon(CupertinoIcons.photo),
-              onPressed: () => OTEditor.uploadImage(context, _controller)),
+            padding: EdgeInsets.zero,
+            icon: PlatformX.isMaterial(context)
+                ? const Icon(Icons.photo)
+                : const Icon(CupertinoIcons.photo),
+            onPressed: () => OTEditor.uploadImage(context, _controller),
+          ),
           PlatformIconButton(
             padding: EdgeInsets.zero,
             icon: PlatformX.isMaterial(context)
@@ -890,14 +1060,17 @@ class BBSEditorPageState extends State<BBSEditorPage> {
                 : const Icon(CupertinoIcons.paperplane),
             onPressed: _canSend
                 ? () async {
-                    bool isCareWordsDetected =
-                        await detectCareWords(_controller.text);
+                    bool isCareWordsDetected = await detectCareWords(
+                      _controller.text,
+                    );
                     // only show once
                     if (context.mounted == true &&
                         isCareWordsDetected == true &&
                         _confirmCareWords == false) {
                       await showPlatformDialog(
-                          context: context, builder: (_) => const CareDialog());
+                        context: context,
+                        builder: (_) => const CareDialog(),
+                      );
                       _confirmCareWords = true;
                       return;
                     }
@@ -908,16 +1081,19 @@ class BBSEditorPageState extends State<BBSEditorPage> {
         ],
       ),
       body: SafeArea(
-          bottom: false,
-          child: Padding(
-              padding: const EdgeInsets.all(8),
-              child: BBSEditorWidget(
-                controller: _controller,
-                allowTags: _supportTags,
-                editorObject: _object,
-                fullscreen: _isFullscreen,
-                tip: _tip,
-              ))),
+        bottom: false,
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: BBSEditorWidget(
+            controller: _controller,
+            allowTags: _supportTags,
+            editorObject: _object,
+            fullscreen: _isFullscreen,
+            requireDivision: _requireDivision,
+            tip: _tip,
+          ),
+        ),
+      ),
     );
   }
 
@@ -925,7 +1101,10 @@ class BBSEditorPageState extends State<BBSEditorPage> {
     String text = _controller.text;
     if (text.isEmpty) return;
     final editorText = PostEditorText(
-        text, context.read<ForumProvider>().editorCache[object]!.tags);
+      text,
+      context.read<ForumProvider>().editorCache[object]!.tags,
+      divisionId: context.read<ForumProvider>().editorCache[object]!.divisionId,
+    );
 
     if ((await _interceptor?.call(context, editorText)) ?? true) {
       Navigator.pop<PostEditorText>(context, editorText);

--- a/lib/page/forum/hole_editor.dart
+++ b/lib/page/forum/hole_editor.dart
@@ -119,6 +119,8 @@ class OTEditor {
     }
 
     // If not specified, then use the value from editor
+    // It is guaranteed by the selection widget that the divisionId is not null,
+    // as long as the division list is non-empty.
     divisionId ??= content!.divisionId!;
 
     ProgressFuture progressDialog = showProgressDialog(
@@ -127,7 +129,7 @@ class OTEditor {
     );
     try {
       await ForumRepository.getInstance().newHole(
-        divisionId!,
+        divisionId,
         content!.text,
         tags: content.tags,
       );

--- a/lib/page/forum/hole_editor.dart
+++ b/lib/page/forum/hole_editor.dart
@@ -98,12 +98,11 @@ final PostInterceptor _kStopWordInterceptor = (context, text) async {
 class OTEditor {
   static Future<bool> createNewPost(
     BuildContext context,
-    int divisionId, {
+    int? divisionId, {
     OTEditorType? editorType,
     PostInterceptor? interceptor,
   }) async {
     final object = EditorObject(0, EditorObjectType.NEW_POST);
-    final requireDivision = divisionId == OTDivision.HOME_PAGE_DIVISION_ID;
     final PostEditorText? content = await _showEditor(
       context,
       S.of(context).new_post,
@@ -111,7 +110,7 @@ class OTEditor {
       editorType: editorType,
       object: object,
       // If the editor is called from homepage, then we have the user select a division here in editor.
-      requireDivision: requireDivision,
+      requireDivision: divisionId == null,
       interceptor: _kStopWordInterceptor.mergeWith(interceptor),
     );
 
@@ -119,9 +118,8 @@ class OTEditor {
       return false;
     }
 
-    if (requireDivision && content?.divisionId != null) {
-      divisionId = content!.divisionId!;
-    }
+    // If not specified, then use the value from editor
+    divisionId ??= content!.divisionId!;
 
     ProgressFuture progressDialog = showProgressDialog(
       loadingText: S.of(context).posting,
@@ -129,7 +127,7 @@ class OTEditor {
     );
     try {
       await ForumRepository.getInstance().newHole(
-        divisionId,
+        divisionId!,
         content!.text,
         tags: content.tags,
       );

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -143,6 +143,12 @@ class OTTitle extends StatelessWidget {
             (value) => value.divisionCache);
     OTDivision? division = context
         .select<ForumProvider, OTDivision?>((value) => value.currentDivision);
+
+    if (division?.division_id == OTDivision.HOME_PAGE_DIVISION_ID) {
+      division!.name = "主页";
+      division.description = "展示所有板块";
+    }
+
     int currentIndex = 0;
     if (division != null) {
       currentIndex = divisions.indexOf(division);
@@ -370,7 +376,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
     if (!context.read<ForumProvider>().isUserInitialized) {
       await ForumRepository.getInstance().initializeRepo();
       context.read<ForumProvider>().currentDivisionId =
-          ForumRepository.getInstance().getDivisions().firstOrNull?.division_id;
+          OTDivision.HOME_PAGE_DIVISION_ID;
     }
 
     bool answered =

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -538,8 +538,9 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
     _fieldInitComplete = false;
     _postSubscription.bindOnlyInvalid(
         Constant.eventBus.on<CreateNewPostEvent>().listen((_) async {
+          final currentDivision = getDivisionId(context);
           final bool success =
-              await OTEditor.createNewPost(context, getDivisionId(context),
+              await OTEditor.createNewPost(context, currentDivision is DivisionId ? currentDivision.id : null,
                   interceptor: (_, PostEditorText? text) async {
             if (text?.tags.isEmpty ?? true) {
               return await Noticing.showConfirmationDialog(

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -140,7 +140,7 @@ class OTTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     // Note: these strings can be (and should be) localized. 
     // But since other division names are not localized (yet), we leave them hardcoded for now. 
-    OTDivision homepageDivision = OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, "主页", "展示所有板块", null);
+    OTDivision homepageDivision = OTDivision(null, "主页", "展示所有板块", null);
 
     List<OTDivision> divisions =
         [homepageDivision, ...context.select<ForumProvider, List<OTDivision>>(
@@ -162,10 +162,15 @@ class OTTitle extends StatelessWidget {
           singleChoice: true,
           defaultChoice: currentIndex,
           onChoice: (Tag tag, list) {
-            division =
+            if (tag.tagTitle == homepageDivision.name) {
+              division = homepageDivision;
+              context.read<ForumProvider>().currentDivisionId = Homepage();
+            } else {
+              division =
                 divisions.firstWhere((element) => element.name == tag.tagTitle);
             context.read<ForumProvider>().currentDivisionId =
-                division?.division_id;
+                DivisionId(division!.division_id!);
+            }
             ChangeDivisionEvent(division!).fire();
           },
           tagList: divisions
@@ -357,8 +362,8 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
       TimeBasedLoadAdaptLayer(Constant.POST_COUNT_PER_PAGE, 1);
 
   /// Fields related to the display states.
-  static int getDivisionId(BuildContext context) =>
-      context.read<ForumProvider>().currentDivision?.division_id ?? OTDivision.HOME_PAGE_DIVISION_ID;
+  static DivisionIdentifier getDivisionId(BuildContext context) =>
+      context.read<ForumProvider>().currentDivisionId ?? Homepage();
 
   FoldBehavior? get foldBehavior => foldBehaviorFromInternalString(
       context.read<ForumProvider>().userInfo?.config?.show_folded);
@@ -374,8 +379,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
     // If no token, NotLoginError will be thrown.
     if (!context.read<ForumProvider>().isUserInitialized) {
       await ForumRepository.getInstance().initializeRepo();
-      context.read<ForumProvider>().currentDivisionId =
-          OTDivision.HOME_PAGE_DIVISION_ID;
+      context.read<ForumProvider>().currentDivisionId = Homepage();
     }
 
     bool answered =
@@ -433,7 +437,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
           final requestDivisionId =
               _tagFilter == null ? getDivisionId(context) : null;
           return ForumRepository.getInstance().loadHoles(
-              time, requestDivisionId,
+              time, requestDivisionId!,
               tag: _tagFilter,
               sortOrder: context.read<SettingsProvider>().forumSortOrder);
         }).call(page);
@@ -492,8 +496,13 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
   }
 
   Widget _autoSilenceNotice() {
+    final division = getDivisionId(context);
+    if (division is! DivisionId) {
+      return const SizedBox();
+    }
+
     final DateTime? silenceDate = ForumRepository.getInstance()
-        .getSilenceDateForDivision(getDivisionId(context))
+        .getSilenceDateForDivision(division.id)
         ?.toLocal();
     if (silenceDate == null || silenceDate.isBefore(DateTime.now())) {
       return const SizedBox();

--- a/lib/page/subpage_forum.dart
+++ b/lib/page/subpage_forum.dart
@@ -138,16 +138,15 @@ class OTTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Note: these strings can be (and should be) localized. 
+    // But since other division names are not localized (yet), we leave them hardcoded for now. 
+    OTDivision homepageDivision = OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, "主页", "展示所有板块", null);
+
     List<OTDivision> divisions =
-        context.select<ForumProvider, List<OTDivision>>(
-            (value) => value.divisionCache);
+        [homepageDivision, ...context.select<ForumProvider, List<OTDivision>>(
+            (value) => value.divisionCache)];
     OTDivision? division = context
         .select<ForumProvider, OTDivision?>((value) => value.currentDivision);
-
-    if (division?.division_id == OTDivision.HOME_PAGE_DIVISION_ID) {
-      division!.name = "主页";
-      division.description = "展示所有板块";
-    }
 
     int currentIndex = 0;
     if (division != null) {
@@ -359,7 +358,7 @@ class ForumSubpageState extends PlatformSubpageState<ForumSubpage> {
 
   /// Fields related to the display states.
   static int getDivisionId(BuildContext context) =>
-      context.read<ForumProvider>().currentDivision?.division_id ?? 1;
+      context.read<ForumProvider>().currentDivision?.division_id ?? OTDivision.HOME_PAGE_DIVISION_ID;
 
   FoldBehavior? get foldBehavior => foldBehaviorFromInternalString(
       context.read<ForumProvider>().userInfo?.config?.show_folded);

--- a/lib/provider/forum_provider.dart
+++ b/lib/provider/forum_provider.dart
@@ -46,19 +46,22 @@ class ForumProvider with ChangeNotifier {
   final Map<String?, CourseReviewEditorText> courseReviewEditorCache = {};
 
   /// The current division id;
-  int? divisionId;
+  DivisionIdentifier? _currentDivision;
 
   OTDivision? get currentDivision {
-    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
-      return OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, null, null, null);
+    if (_currentDivision is! DivisionId) {
+      return null;
     }
 
+    int divisionId = (_currentDivision as DivisionId).id;
     return _divisionCache
       .firstWhereOrNull((element) => element.division_id == divisionId);
   } 
 
-  set currentDivisionId(int? divisionId) {
-    this.divisionId = divisionId;
+  DivisionIdentifier? get currentDivisionId => _currentDivision;
+
+  set currentDivisionId(DivisionIdentifier? division) {
+    _currentDivision = division;
     notifyListeners();
   }
 

--- a/lib/provider/forum_provider.dart
+++ b/lib/provider/forum_provider.dart
@@ -48,8 +48,14 @@ class ForumProvider with ChangeNotifier {
   /// The current division id;
   int? divisionId;
 
-  OTDivision? get currentDivision => _divisionCache
+  OTDivision? get currentDivision {
+    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
+      return OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, null, null, null);
+    }
+
+    return _divisionCache
       .firstWhereOrNull((element) => element.division_id == divisionId);
+  } 
 
   set currentDivisionId(int? divisionId) {
     this.divisionId = divisionId;

--- a/lib/provider/state_provider.dart
+++ b/lib/provider/state_provider.dart
@@ -17,6 +17,7 @@
 
 import 'package:dan_xi/model/person.dart';
 import 'package:dan_xi/provider/forum_provider.dart';
+import 'package:dan_xi/model/forum/division.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:provider/provider.dart';
 
@@ -38,7 +39,7 @@ class StateProvider {
 
   static void initialize(BuildContext context) {
     ForumProvider provider = context.read<ForumProvider>();
-    provider.currentDivisionId = null;
+    provider.currentDivisionId = const Homepage();
     isLoggedIn.value = false;
     personInfo.value = null;
     isForeground = true;

--- a/lib/repository/forum/forum_repository.dart
+++ b/lib/repository/forum/forum_repository.dart
@@ -289,7 +289,7 @@ class ForumRepository extends BaseRepositoryWithDio {
         await WebvpnProxy.requestWithProxy(dio, options);
     final result = response.data?.map((e) => OTDivision.fromJson(e)).toList();
     if (result != null) {
-      provider.divisionCache = result;
+      provider.divisionCache = [OTDivision.home_page_division, ...result];
     }
     return provider.divisionCache.isNotEmpty ? provider.divisionCache : null;
   }
@@ -309,6 +309,10 @@ class ForumRepository extends BaseRepositoryWithDio {
 
   Future<OTDivision?> loadSpecificDivision(int divisionId,
       {bool useCache = true}) async {
+    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
+      return OTDivision.home_page_division;
+    }
+
     if (useCache) {
       try {
         final OTDivision cached = provider.divisionCache
@@ -335,17 +339,31 @@ class ForumRepository extends BaseRepositoryWithDio {
       String? tag,
       SortOrder? sortOrder}) async {
     sortOrder ??= SortOrder.LAST_REPLIED;
-    final options = RequestOptions(
-        path: "$_BASE_URL/holes",
-        method: "GET",
-        queryParameters: {
-          "start_time": startTime.toUtc().toIso8601String(),
-          "division_id": divisionId ?? 0, // 0 = don't filter by division
-          "length": length,
-          "tag": tag,
-          "order": sortOrder.getInternalString()
-        },
-        headers: _tokenHeader);
+
+    RequestOptions options;
+    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
+      options = RequestOptions(
+          path: "$_BASE_URL/holes/_homepage",
+          method: "GET",
+          queryParameters: {
+            "offset": startTime.toUtc().toIso8601String(),
+            "size": length,
+            "order": sortOrder.getInternalString()
+          },
+          headers: _tokenHeader);
+    } else {
+      options = RequestOptions(
+          path: "$_BASE_URL/holes",
+          method: "GET",
+          queryParameters: {
+            "start_time": startTime.toUtc().toIso8601String(),
+            "division_id": divisionId ?? 0, // 0 = don't filter by division
+            "length": length,
+            "tag": tag,
+            "order": sortOrder.getInternalString()
+          },
+          headers: _tokenHeader);
+    }
 
     final Response<List<dynamic>> response =
         await WebvpnProxy.requestWithProxy(dio, options);

--- a/lib/repository/forum/forum_repository.dart
+++ b/lib/repository/forum/forum_repository.dart
@@ -312,12 +312,8 @@ class ForumRepository extends BaseRepositoryWithDio {
 
   List<OTDivision> getDivisions() => provider.divisionCache;
 
-  Future<OTDivision?> loadSpecificDivision(DivisionIdentifier division,
+  Future<OTDivision?> loadSpecificDivision(DivisionId division,
       {bool useCache = true}) async {
-    if (division is! DivisionId) {
-      return null;
-    }
-    
     int divisionId = division.id;
     if (useCache) {
       try {

--- a/lib/repository/forum/forum_repository.dart
+++ b/lib/repository/forum/forum_repository.dart
@@ -294,10 +294,15 @@ class ForumRepository extends BaseRepositoryWithDio {
     return provider.divisionCache.isNotEmpty ? provider.divisionCache : null;
   }
 
-  List<OTHole> getPinned(int divisionId) {
+  List<OTHole> getPinned(DivisionIdentifier division) {
+    // No API for pinned holes on homepage yet
+    if (division is! DivisionId){
+      return [];
+    }
+
     try {
       return provider.divisionCache
-              .firstWhere((element) => element.division_id == divisionId)
+              .firstWhere((element) => element.division_id == division.id)
               .pinned ??
           [];
     } catch (ignored) {
@@ -307,12 +312,13 @@ class ForumRepository extends BaseRepositoryWithDio {
 
   List<OTDivision> getDivisions() => provider.divisionCache;
 
-  Future<OTDivision?> loadSpecificDivision(int divisionId,
+  Future<OTDivision?> loadSpecificDivision(DivisionIdentifier division,
       {bool useCache = true}) async {
-    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
-      return OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, null, null, null);
+    if (division is! DivisionId) {
+      return null;
     }
-
+    
+    int divisionId = division.id;
     if (useCache) {
       try {
         final OTDivision cached = provider.divisionCache
@@ -334,14 +340,14 @@ class ForumRepository extends BaseRepositoryWithDio {
     return newDivision;
   }
 
-  Future<List<OTHole>?> loadHoles(DateTime startTime, int? divisionId,
+  Future<List<OTHole>?> loadHoles(DateTime startTime, DivisionIdentifier division,
       {int length = Constant.POST_COUNT_PER_PAGE,
       String? tag,
       SortOrder? sortOrder}) async {
     sortOrder ??= SortOrder.LAST_REPLIED;
 
     RequestOptions options;
-    if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
+    if (division is Homepage) {
       options = RequestOptions(
           path: "$_BASE_URL/holes/_homepage",
           method: "GET",
@@ -352,18 +358,22 @@ class ForumRepository extends BaseRepositoryWithDio {
             "order": sortOrder.getInternalString()
           },
           headers: _tokenHeader);
-    } else {
+    } else if (division is DivisionId) {
+      int divisionId = division.id;
       options = RequestOptions(
           path: "$_BASE_URL/holes",
           method: "GET",
           queryParameters: {
             "start_time": startTime.toUtc().toIso8601String(),
-            "division_id": divisionId ?? 0, // 0 = don't filter by division
+            "division_id": divisionId,
             "length": length,
             "tag": tag,
             "order": sortOrder.getInternalString()
           },
           headers: _tokenHeader);
+    } else {
+      // Unknown division identifier
+      return null;
     }
 
     final Response<List<dynamic>> response =

--- a/lib/repository/forum/forum_repository.dart
+++ b/lib/repository/forum/forum_repository.dart
@@ -289,7 +289,7 @@ class ForumRepository extends BaseRepositoryWithDio {
         await WebvpnProxy.requestWithProxy(dio, options);
     final result = response.data?.map((e) => OTDivision.fromJson(e)).toList();
     if (result != null) {
-      provider.divisionCache = [OTDivision.home_page_division, ...result];
+      provider.divisionCache = result;
     }
     return provider.divisionCache.isNotEmpty ? provider.divisionCache : null;
   }
@@ -310,7 +310,7 @@ class ForumRepository extends BaseRepositoryWithDio {
   Future<OTDivision?> loadSpecificDivision(int divisionId,
       {bool useCache = true}) async {
     if (divisionId == OTDivision.HOME_PAGE_DIVISION_ID) {
-      return OTDivision.home_page_division;
+      return OTDivision(OTDivision.HOME_PAGE_DIVISION_ID, null, null, null);
     }
 
     if (useCache) {
@@ -346,8 +346,9 @@ class ForumRepository extends BaseRepositoryWithDio {
           path: "$_BASE_URL/holes/_homepage",
           method: "GET",
           queryParameters: {
-            "offset": startTime.toUtc().toIso8601String(),
-            "size": length,
+            "start_time": startTime.toUtc().toIso8601String(),
+            "length": length,
+            "tag": tag,
             "order": sortOrder.getInternalString()
           },
           headers: _tokenHeader);

--- a/lib/widget/forum/tag_selector/selector.dart
+++ b/lib/widget/forum/tag_selector/selector.dart
@@ -107,7 +107,9 @@ class TagContainerState extends State<TagContainer> {
     widget.fontSize == null ? fontSize = 16 : fontSize = widget.fontSize;
     widget.iconSize == null ? iconSize = 22 : iconSize = widget.iconSize;
     if (widget.defaultChoice! >= 0 && tagList!.length > widget.defaultChoice!) {
-      tagList![widget.defaultChoice!].isSelected = true;
+      if (tagList!.every((element) => !element.isSelected)){
+        tagList![widget.defaultChoice!].isSelected = true;
+      }
     }
     fillRandomColor = widget.fillRandomColor;
     fillRandomColor


### PR DESCRIPTION
A alternative design to #655, but implementing the same feature.  
This PR converts division to a enum, as followed: 
```rust
enum DivisionIdentifier {
    Homepage,
    DivisionId(int)
}
```
I am not sure whether naming the superclass as `DivisionIdentifier` would be appropriate, since it feels like the same meaning of one of its subtypes `DivisionId`. Tell me to rename it if there's a better candidate name. 