### PR TITLE
fix: avoid setting `thisSemesterStartDate` when it is missing

### DIFF
--- a/lib/page/subpage_timetable.dart
+++ b/lib/page/subpage_timetable.dart
@@ -683,8 +683,11 @@ class SemesterSelectionButtonState extends State<SemesterSelectionButton> {
     }
     SettingsProvider.getInstance().semesterStartDates =
         semesterBundle.startDates;
-    SettingsProvider.getInstance().thisSemesterStartDate =
-        semesterBundle.startDates.parseStartDate(chosenSemester);
+    semesterBundle.startDates
+        .parseStartDate(chosenSemester)
+        ?.apply(
+          (sd) => SettingsProvider.getInstance().thisSemesterStartDate = sd,
+        );
   }
 
   @override

--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -179,7 +179,8 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set timetableSemester(String? value) {
-    preferences!.setString(KEY_TIMETABLE_SEMESTER, value!);
+    value!;
+    preferences!.setString(KEY_TIMETABLE_SEMESTER, value);
     notifyListeners();
   }
 
@@ -356,7 +357,8 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set thisSemesterStartDate(String? value) {
-    preferences!.setString(KEY_THIS_SEMESTER_START_DATE, value!);
+    value!;
+    preferences!.setString(KEY_THIS_SEMESTER_START_DATE, value);
     notifyListeners();
   }
 
@@ -369,7 +371,8 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set semesterStartDates(SemesterStartDates? value) {
-    preferences!.setString(KEY_SEMESTER_START_DATES, jsonEncode(value!));
+    value!;
+    preferences!.setString(KEY_SEMESTER_START_DATES, jsonEncode(value));
     notifyListeners();
   }
 

--- a/lib/provider/settings_provider.dart
+++ b/lib/provider/settings_provider.dart
@@ -179,8 +179,11 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set timetableSemester(String? value) {
-    value!;
-    preferences!.setString(KEY_TIMETABLE_SEMESTER, value);
+    if (value != null) {
+      preferences!.setString(KEY_TIMETABLE_SEMESTER, value);
+    } else {
+      preferences!.remove(KEY_TIMETABLE_SEMESTER);
+    }
     notifyListeners();
   }
 
@@ -357,8 +360,11 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set thisSemesterStartDate(String? value) {
-    value!;
-    preferences!.setString(KEY_THIS_SEMESTER_START_DATE, value);
+    if (value != null) {
+      preferences!.setString(KEY_THIS_SEMESTER_START_DATE, value);
+    } else {
+      preferences!.remove(KEY_THIS_SEMESTER_START_DATE);
+    }
     notifyListeners();
   }
 
@@ -371,8 +377,11 @@ class SettingsProvider with ChangeNotifier {
   }
 
   set semesterStartDates(SemesterStartDates? value) {
-    value!;
-    preferences!.setString(KEY_SEMESTER_START_DATES, jsonEncode(value));
+    if (value != null) {
+      preferences!.setString(KEY_SEMESTER_START_DATES, jsonEncode(value));
+    } else {
+      preferences!.remove(KEY_SEMESTER_START_DATES);
+    }
     notifyListeners();
   }
 

--- a/lib/repository/fdu/edu_service_repository.dart
+++ b/lib/repository/fdu/edu_service_repository.dart
@@ -29,9 +29,6 @@ import 'package:flutter/widgets.dart';
 import 'neo_login_tool.dart';
 
 class EduServiceRepository extends BaseRepositoryWithDio {
-  static const String COURSE_TABLE_URL =
-      'https://fdjwgl.fudan.edu.cn/student/for-std/course-table';
-
   static String getSemesterCourseTableUrl(String semesterId) =>
       'https://fdjwgl.fudan.edu.cn/student/for-std/course-table/semester/$semesterId/print-data';
 


### PR DESCRIPTION
For example this semester [1] does not have a start date specified in
the fetched data [2].

[1]
```html
                  <option name="semesterAssoc" value="528">2025-2026学年暑期</option>
```

[2]
```js
  var semesters = JSON.parse([
    {"startDate":"2026-03-01","endDate":"2026-07-04","name":"2025-2026学年2学期","id":505},
    {"startDate":"2025-09-07","endDate":"2026-01-10","name":"2025-2026学年1学期","id":504},
    {"startDate":"2025-06-22","endDate":"2025-09-06","name":"2024-2025学年暑期","id":506},
    {"startDate":"2025-02-16","endDate":"2025-06-21","name":"2024-2025学年2学期","id":469},
    {"startDate":"2024-09-01","endDate":"2025-01-04","name":"2024-2025学年1学期","id":467},
    {"startDate":"2024-02-25","endDate":"2024-06-29","name":"2023-2024学年2学期","id":464},
    {"startDate":"2023-09-03","endDate":"2024-01-06","name":"2023-2024学年1学期","id":444},
    {"startDate":"2023-02-19","endDate":"2023-06-24","name":"2022-2023学年2学期","id":425},
    {"startDate":"2022-09-04","endDate":"2023-01-07","name":"2022-2023学年1学期","id":404}
  ]);
```
