### PR TITLE
feat(hole_detail): add a button to load new floors and go to the end

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -356,6 +356,7 @@
   "screenshot_warning": "To ensure data security and to protect the privacy of other users, please do not send screenshots to any other platform. Thank you for your cooperation.",
   "screenshot_warning_title": "Screenshot Detected",
   "scroll_to_end": "Go to Bottom",
+  "scroll_to_new": "Go to New Posts",
   "search": "Search",
   "search_by_floor_tip": "Go to the floor {floorId}",
   "search_by_pid_tip": "Go to the post {pid}",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -348,6 +348,7 @@
   "screenshot_warning": "フォーラムの情報のセキュリティと他のユーザーのプライバシーを保護するために、スクリーンショットを他のプラットフォームに送信しないようにお願いします。ご協力ありがとうございました。",
   "screenshot_warning_title": "スクリーンショットを検知",
   "scroll_to_end": "底へ行く",
+  "scroll_to_new": "新しい投稿へ行く",
   "search": "検索",
   "search_by_floor_tip": "「{floorId}」返信へ",
   "search_by_pid_tip": "「{pid}」ポストへ",

--- a/lib/l10n/intl_zh_Hans.arb
+++ b/lib/l10n/intl_zh_Hans.arb
@@ -350,6 +350,7 @@
   "screenshot_warning": "为保障茶楼信息安全和其他用户的隐私，请不要将截图发送到任何平台，感谢您的配合。",
   "screenshot_warning_title": "检测到截图",
   "scroll_to_end": "去往底部",
+  "scroll_to_new": "去往新回复",
   "search": "搜索",
   "search_by_floor_tip": "跳转到楼层「{floorId}」",
   "search_by_pid_tip": "跳转到帖子「{pid}」",

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -350,6 +350,7 @@
   "screenshot_warning": "爲保障茶樓資訊安全及其他使用者的隱私，請勿將截圖傳送至任何平台，感謝您的配合。",
   "screenshot_warning_title": "偵測到截圖",
   "scroll_to_end": "前往底部",
+  "scroll_to_new": "前往新回覆",
   "search": "搜尋",
   "search_by_floor_tip": "跳轉至樓層「{floorId}」",
   "search_by_pid_tip": "跳轉至帖子「{pid}」",

--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -425,18 +425,8 @@ class BBSPostDetailState extends State<BBSPostDetail> {
         }
 
         if (shouldScrollToEnd) {
-          try {
-            if (!_allDataLoaded) {
-              await _loadAllContent();
-            }
-            // scroll to end.
-            _listViewController.scheduleLoadedCallback(
-                () async => await _listViewController.scrollToEnd(),
-                rebuild: true);
-            shouldScrollToEnd = false;
-          } catch (_) {
-            // we don't care if we failed to scroll to the end.
-          }
+          await _loadAllAndScrollToEnd();
+          shouldScrollToEnd = false;
         }
       }
     });
@@ -539,6 +529,14 @@ class BBSPostDetailState extends State<BBSPostDetail> {
             ),
             PlatformPopupMenuX(
               options: [
+                PopupMenuOption(
+                  label: S.of(context).scroll_to_new,
+                  onTap: (_) {
+                    _allDataLoaded = false;
+                    _loadAllContentFuture = null;
+                    _loadAllAndScrollToEnd();
+                  },
+                ),
                 PopupMenuOption(
                     label: S.of(context).scroll_to_end,
                     onTap: (_) {
@@ -818,6 +816,21 @@ class BBSPostDetailState extends State<BBSPostDetail> {
     _listViewController.replaceAllDataWith(allFloors);
     _allDataLoaded = true;
     return allFloors;
+  }
+
+  Future<void> _loadAllAndScrollToEnd() async {
+    try {
+      if (!_allDataLoaded) {
+        await _loadAllContent();
+      }
+      // scroll to end.
+      _listViewController.scheduleLoadedCallback(
+        () async => await _listViewController.scrollToEnd(),
+        rebuild: true,
+      );
+    } catch (_) {
+      // we don't care if we failed to scroll to the end.
+    }
   }
 
   Widget _buildFavoredActionButton() {


### PR DESCRIPTION
In a hole with many floors, if the user wants to view the new posts, they needs to scroll to the begin, pull it down to refresh, and scroll to the end again, or they needs to quit the hole and re-open it.

This commit introduced a button to load new posts and go to the end, which simplifies the operation.