### PR TITLE
fix(windows): restore Simplified Chinese font fallback

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -307,9 +307,7 @@ class DanxiApp extends StatelessWidget {
                   ],
                   locale: LanguageManager.toLocale(
                       context.watch<SettingsProvider>().language),
-                  // Configure supported locales. Hard-code "zh-CN" locale for correct Chinese font selection on Windows.
-                  // See https://github.com/flutter/flutter/issues/103811#issuecomment-1199012026 for details.
-                  supportedLocales: [...S.delegate.supportedLocales, const Locale('zh', 'CN')],
+                  supportedLocales: S.delegate.supportedLocales,
                   onUnknownRoute: (settings) => throw AssertionError(
                       "ERROR: onUnknownRoute() has been called inside the root navigator.\nDevelopers are not supposed to push on this Navigator. There should be something wrong in the code."),
                   home: ThemedSystemOverlay(

--- a/lib/provider/language_manager.dart
+++ b/lib/provider/language_manager.dart
@@ -11,7 +11,7 @@ class LanguageManager {
       Language.JAPANESE => const Locale("ja"),
       Language.SIMPLIFIED_CHINESE => const Locale.fromSubtags(
         languageCode: "zh",
-        scriptCode: "Hans",
+        countryCode: "CN",
       ),
       Language.TRADITIONAL_CHINESE => const Locale.fromSubtags(
         languageCode: "zh",

--- a/test/provider/language_manager_test.dart
+++ b/test/provider/language_manager_test.dart
@@ -1,0 +1,23 @@
+import 'package:dan_xi/common/constant.dart';
+import 'package:dan_xi/provider/language_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LanguageManager.toLocale', () {
+    test('uses the mainland Chinese locale for Simplified Chinese', () {
+      final locale = LanguageManager.toLocale(Language.SIMPLIFIED_CHINESE);
+
+      expect(locale.languageCode, 'zh');
+      expect(locale.scriptCode, isNull);
+      expect(locale.countryCode, 'CN');
+    });
+
+    test('keeps Traditional Chinese on the traditional script locale', () {
+      final locale = LanguageManager.toLocale(Language.TRADITIONAL_CHINESE);
+
+      expect(locale.languageCode, 'zh');
+      expect(locale.scriptCode, 'Hant');
+      expect(locale.countryCode, isNull);
+    });
+  });
+}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -50,6 +50,12 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# gal currently relies on permissive MSVC language behavior. Keep the
+# workaround scoped to the plugin instead of weakening conformance globally.
+if(MSVC AND TARGET gal_plugin)
+  target_compile_options(gal_plugin PRIVATE /permissive)
+endif()
+
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
Use the zh-CN locale for Simplified Chinese so Flutter selects the correct Windows CJK glyphs while retaining zh-Hant for Traditional Chinese.

Apply MSVC /permissive only to gal_plugin, enabling building on lower Windows SDK version.

Add locale regression tests for Simplified and Traditional Chinese.

Validated with flutter test and flutter build windows --debug.

Before:
<img width="459" height="892" alt="before" src="https://github.com/user-attachments/assets/b7a89d71-e133-4cae-b83e-967545a720ba" />

After:
<img width="459" height="892" alt="after" src="https://github.com/user-attachments/assets/9b72a3df-87d0-4a97-b831-ef1a87303565" />



_* LLM usage claim: some code is generated with the assistance of gpt-5.6-sol_