### PR TITLE
Fix copy page

### DIFF
--- a/lib/page/forum/text_selector.dart
+++ b/lib/page/forum/text_selector.dart
@@ -50,10 +50,13 @@ class TextSelectorPageState extends State<TextSelectorPage> {
         appBar: PlatformAppBarX(
           title: Text(S.of(context).free_select),
         ),
-        body: PostRenderWidget(
-          render: kMarkdownSelectorRender,
-          content: widget.arguments!['text'],
-          hasBackgroundImage: false,
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: PostRenderWidget(
+            render: kMarkdownSelectorRender,
+            content: widget.arguments!['text'],
+            hasBackgroundImage: false,
+          ),
         ));
   }
 }

--- a/lib/page/forum/text_selector.dart
+++ b/lib/page/forum/text_selector.dart
@@ -50,13 +50,10 @@ class TextSelectorPageState extends State<TextSelectorPage> {
         appBar: PlatformAppBarX(
           title: Text(S.of(context).free_select),
         ),
-        body: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: PostRenderWidget(
-            render: kMarkdownSelectorRender,
-            content: widget.arguments!['text'],
-            hasBackgroundImage: false,
-          ),
+        body: PostRenderWidget(
+          render: kMarkdownSelectorRender,
+          content: widget.arguments!['text'],
+          hasBackgroundImage: false,
         ));
   }
 }

--- a/lib/widget/forum/render/render_impl.dart
+++ b/lib/widget/forum/render/render_impl.dart
@@ -219,7 +219,7 @@ final BaseRender kMarkdownSelectorRender = (BuildContext context,
     LinkTapCallback? onTapLink,
     ImageLongPressCallback? onLongPressImage}) {
   return SelectionArea(
-    child: Markdown(
+    child: MarkdownBody(
       softLineBreak: true,
       data: content!,
       styleSheet: _markdownStyleOverride(

--- a/lib/widget/forum/render/render_impl.dart
+++ b/lib/widget/forum/render/render_impl.dart
@@ -32,7 +32,6 @@ import 'package:flutter_math_fork/flutter_math.dart';
 import 'package:highlighting/languages/all.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:markdown/markdown.dart' as md;
-import 'package:nil/nil.dart';
 
 const double kFontSize = 16.0;
 const double kFontLargerSize = 24.0;
@@ -226,7 +225,8 @@ final BaseRender kMarkdownSelectorRender = (BuildContext context,
           _getMarkdownStyleSheetFromPlatform(context), kFontLargerSize),
       onTapLink: (String text, String? href, String title) =>
           onTapLink?.call(href),
-      imageBuilder: (Uri uri, String? title, String? alt) => nil,
+      imageBuilder: (Uri uri, String? title, String? alt) =>
+          const SizedBox.shrink(),
     ),
   );
 };

--- a/lib/widget/forum/render/render_impl.dart
+++ b/lib/widget/forum/render/render_impl.dart
@@ -218,7 +218,7 @@ final BaseRender kMarkdownSelectorRender = (BuildContext context,
     LinkTapCallback? onTapLink,
     ImageLongPressCallback? onLongPressImage}) {
   return SelectionArea(
-    child: MarkdownBody(
+    child: Markdown(
       softLineBreak: true,
       data: content!,
       styleSheet: _markdownStyleOverride(

--- a/test/text_selector_page_test.dart
+++ b/test/text_selector_page_test.dart
@@ -52,7 +52,12 @@ void main() {
       (tester) async {
     final paragraph = '这是一段用于测试长文本选择复制功能的楼层内容。';
     final longContent =
-        List.generate(120, (index) => '$index $paragraph').join('\n\n');
+        List.generate(120, (index) {
+      final image = index % 10 == 0
+          ? '\n\n![图片](https://example.com/img/$index.png)'
+          : '';
+      return '$index $paragraph$image';
+    }).join('\n\n');
 
     await tester.pumpWidget(MaterialApp(
       localizationsDelegates: const [

--- a/test/text_selector_page_test.dart
+++ b/test/text_selector_page_test.dart
@@ -77,7 +77,7 @@ void main() {
     // Scroll to the bottom: the content must not be stuck and the last
     // paragraph must become visible.
     await tester.fling(
-        find.byType(SingleChildScrollView), const Offset(0, -8000), 6000);
+        find.byType(ListView), const Offset(0, -8000), 6000);
     await tester.pumpAndSettle();
 
     expect(find.text('119 $paragraph'), findsOneWidget);

--- a/test/text_selector_page_test.dart
+++ b/test/text_selector_page_test.dart
@@ -1,0 +1,80 @@
+/*
+ *     Copyright (C) 2021  DanXi-Dev
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import 'package:dan_xi/generated/l10n.dart';
+import 'package:dan_xi/page/forum/text_selector.dart';
+import 'package:dan_xi/provider/settings_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+      (call) async {
+        switch (call.method) {
+          case 'read':
+            return '0123456789abcdef';
+          case 'readAll':
+            return <String, String>{};
+          case 'containsKey':
+            return true;
+          default:
+            return null;
+        }
+      },
+    );
+    SharedPreferences.setMockInitialValues({});
+    await SettingsProvider.getInstance().init();
+  });
+
+  testWidgets(
+      'TextSelectorPage stays scrollable on long markdown content with selection',
+      (tester) async {
+    final paragraph = '这是一段用于测试长文本选择复制功能的楼层内容。';
+    final longContent =
+        List.generate(120, (index) => '$index $paragraph').join('\n\n');
+
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        S.delegate,
+      ],
+      supportedLocales: S.delegate.supportedLocales,
+      home: TextSelectorPage(arguments: {'text': longContent}),
+    ));
+
+    // The page renders the whole markdown inside a selectable region.
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(find.text('0 $paragraph'), findsOneWidget);
+
+    // Scroll to the bottom: the content must not be stuck and the last
+    // paragraph must become visible.
+    await tester.fling(
+        find.byType(SingleChildScrollView), const Offset(0, -8000), 6000);
+    await tester.pumpAndSettle();
+
+    expect(find.text('119 $paragraph'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
虽然分支名字是 fix-long-text-copy-page，但是我修的时候才发现这个问题可能是因为帖子带图导致的。

问题简述：带图的帖子进入“选择复制”页面后加载到图就卡死。

示例串：#686527

具体分析：选择复制页的 `kMarkdownSelectorRender` 里 `imageBuilder: (uri, title, alt) => nil`，这个 `nil`是一个完全没有 `render object` 的 `widget`。Flutter 布局行内 widget 时会包一层 `_RenderScaledInlineWidget`，它的 `performLayout()` 有个分支：child 为 null 时直接 return 不设置 size，导致触发 “RenderBox did not set its size” 布局断言，导致页面渲染失败。

修复：`nil` 换成零尺寸但有 `render object` 的 `const SizedBox.shrink()`。