### PR TITLE
refactor: remove nil package dependency

### DIFF
--- a/lib/page/dashboard/exam_detail.dart
+++ b/lib/page/dashboard/exam_detail.dart
@@ -37,7 +37,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:ical/serializer.dart';
-import 'package:nil/nil.dart';
 import 'package:open_file/open_file.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -527,7 +526,7 @@ class ExamList extends HookConsumerWidget {
                             _buildGradeContainer(score.level, score.score)
                           ],
                         )
-                      : nil,
+                      : null,
                 )
               ] else ...[
                 Expanded(

--- a/lib/page/forum/hole_detail.dart
+++ b/lib/page/forum/hole_detail.dart
@@ -57,7 +57,6 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:flutter_progress_dialog/flutter_progress_dialog.dart';
 import 'package:intl/intl.dart';
 import 'package:linkify/linkify.dart';
-import 'package:nil/nil.dart';
 import 'package:provider/provider.dart';
 
 /// This function preprocesses content downloaded from FDUHOLE so that
@@ -1485,7 +1484,7 @@ class BBSPostDetailState extends State<BBSPostDetail> {
       {bool isNested = false}) {
     if (_renderModel case Normal(selectedPerson: var selectedPerson, hole: _)) {
       if (selectedPerson != null && floor.anonyname != selectedPerson) {
-        return nil;
+        return const SizedBox.shrink();
       }
     }
 

--- a/lib/page/subpage_settings.dart
+++ b/lib/page/subpage_settings.dart
@@ -57,7 +57,6 @@ import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:flutter_progress_dialog/flutter_progress_dialog.dart';
 import 'package:in_app_review/in_app_review.dart';
-import 'package:nil/nil.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -209,7 +208,6 @@ class SettingsPageState extends State<SettingsPage> {
         "js", LICENSE_BSD_3_0_CLAUSE, "https://github.com/dart-lang/sdk"),
     LicenseItem("device_info_plus", LICENSE_BSD_3_0_CLAUSE,
         "https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus"),
-    LicenseItem("nil", LICENSE_MIT, "https://github.com/letsar/nil"),
     LicenseItem("flex_color_picker", LICENSE_BSD_3_0_CLAUSE,
         "https://github.com/rydmike/flex_color_picker"),
     LicenseItem("material_color_generator", LICENSE_BSD_2_0_CLAUSE,
@@ -993,7 +991,7 @@ class SettingsPageState extends State<SettingsPage> {
                                 .isMarkdownRenderingEnabled;
                       }),
                 ListTile(
-                  leading: nil,
+                  leading: null,
                   title: Text(S.of(context).modify_password),
                   onTap: () {
                     HapticFeedbackUtil.light();
@@ -1002,7 +1000,7 @@ class SettingsPageState extends State<SettingsPage> {
                       }
                 ),
                 ListTile(
-                  leading: nil,
+                  leading: null,
                   title: Text(S.of(context).list_my_posts),
                   onTap: () {
                     HapticFeedbackUtil.light();
@@ -1012,7 +1010,7 @@ class SettingsPageState extends State<SettingsPage> {
                       }
                 ),
                 ListTile(
-                  leading: nil,
+                  leading: null,
                   title: Text(S.of(context).list_my_replies),
                   onTap: () {
                     HapticFeedbackUtil.light();
@@ -1022,7 +1020,7 @@ class SettingsPageState extends State<SettingsPage> {
                       }
                 ),
                 ListTile(
-                  leading: nil,
+                  leading: null,
                   title: Text(S.of(context).list_view_history),
                   onTap: () {
                     HapticFeedbackUtil.light();
@@ -1032,7 +1030,7 @@ class SettingsPageState extends State<SettingsPage> {
                       }
                 ),
                 ListTile(
-                  leading: nil,
+                  leading: null,
                   title: Text(S.of(context).list_my_punishments),
                   onTap: () {
                     HapticFeedbackUtil.light();
@@ -1042,7 +1040,7 @@ class SettingsPageState extends State<SettingsPage> {
                 ),
               ],
               ListTile(
-                leading: nil,
+                leading: null,
                 title: context.read<ForumProvider>().isUserInitialized
                     ? Text(
                         S.of(context).logout,
@@ -1283,7 +1281,7 @@ class SettingsPageState extends State<SettingsPage> {
                       builder:
                           (BuildContext context, AsyncSnapshot<bool> snapshot) {
                         if (snapshot.hasError || snapshot.data == false) {
-                          return nil;
+                          return const SizedBox.shrink();
                         }
                         return TextButton(
                           child: Text(S.of(context).rate),

--- a/lib/util/smart_widget.dart
+++ b/lib/util/smart_widget.dart
@@ -17,7 +17,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:nil/nil.dart';
 
 /// A helper class to convert [String], [WidgetBuilder], [List<Widget>] or something similar into [Widget].
 class SmartWidget {
@@ -28,7 +27,7 @@ class SmartWidget {
       Widget? child,
       VoidCallback? onStepContinue,
       VoidCallback? onStepCancel}) {
-    fallback ??= nil;
+    fallback ??= const SizedBox.shrink();
     if (object == null) return fallback;
 
     if (object is String) {

--- a/lib/widget/forum/auto_bbs_image.dart
+++ b/lib/widget/forum/auto_bbs_image.dart
@@ -20,7 +20,6 @@ import 'package:dan_xi/util/io/cache_manager_with_webvpn.dart';
 import 'package:dan_xi/widget/forum/render/base_render.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
-import 'package:nil/nil.dart';
 
 class BBSImagePlaceholder extends StatelessWidget {
   final Widget? child;
@@ -82,7 +81,7 @@ class AutoBBSImage extends StatelessWidget {
                   return BBSImagePlaceholder(
                     size: maxWidth,
                     child: progress.progress == null
-                        ? nil
+                        ? null
                         : LinearProgressIndicator(
                             value: progress.progress,
                           ),

--- a/lib/widget/forum/forum_widgets.dart
+++ b/lib/widget/forum/forum_widgets.dart
@@ -47,7 +47,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:flutter_progress_dialog/flutter_progress_dialog.dart';
-import 'package:nil/nil.dart';
 import 'package:provider/provider.dart';
 
 /// The ellipsis char. From packages/flutter/lib/src/rendering/paragraph.dart.
@@ -74,7 +73,7 @@ void launchUrlWithNotice(BuildContext context, LinkableElement link) async {
 /// Turn tags into Widgets
 Widget generateTagWidgets(BuildContext context, OTHole? e,
     void Function(String?) onTap, bool useAccessibilityColoring) {
-  if (e == null || e.tags == null) return nil;
+  if (e == null || e.tags == null) return const SizedBox.shrink();
   List<Widget> tags = [];
   for (var element in e.tags!) {
     if (element.name == KEY_NO_TAG) continue;
@@ -750,7 +749,7 @@ class OTFloorMentionWidget extends StatelessWidget {
         successBuilder:
             (BuildContext context, AsyncSnapshot<OTFloor?> snapshot) {
           if (snapshot.data!.content?.isEmpty ?? true) {
-            return nil;
+            return const SizedBox.shrink();
           }
           return OTFloorWidget(
             hasBackgroundImage: hasBackgroundImage,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1231,10 +1231,10 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1283,14 +1283,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  nil:
-    dependency: "direct main"
-    description:
-      name: nil
-      sha256: ef05770c48942876d843bf6a4822d35e5da0ff893a61f1d5ad96d15c4a659136
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.1"
   no_screenshot:
     dependency: "direct main"
     description:
@@ -2037,26 +2029,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,7 +80,6 @@ dependencies:
   lunar: ^1.2.20
   flutter_fgbg: ^0.8.0
   lazy_load_indexed_stack: ^1.0.0
-  nil: ^1.1.1
   flex_color_picker: ^3.2.0
   material_color_generator: ^1.1.0
   flutter_swiper_view: ^1.1.8


### PR DESCRIPTION
接 #689 移除了所有 `nil` 依赖。允许 `null` 的地方直接改 `null`；必须返回非空 `Widget` 的地方用 `SizedBox.shrink()`。

P.S.：因为我是新生，无法测试成绩三元空分支的情况；此外，由于没找到没有标签的串，也没有测试当串标签列表为空时的渲染情况。其余组件应当是正常运行的。