### PR TITLE
fix: customize riverpod retry to avoid ignoring TermsNotAgreed

### DIFF
--- a/lib/widget/dialogs/qr_code_dialog.dart
+++ b/lib/widget/dialogs/qr_code_dialog.dart
@@ -25,6 +25,7 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:riverpod/riverpod.dart'; // 为 ProviderContainer.defaultRetry
 
 part 'qr_code_dialog.g.dart';
 
@@ -34,16 +35,22 @@ class QRHelper {
     try {
       ScreenProxy.setBrightness(1.0);
       await showPlatformDialog(
-          context: context,
-          barrierDismissible: false,
-          builder: (BuildContext context) => QRDialog());
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) => QRDialog(),
+      );
     } finally {
       ScreenProxy.resetBrightness();
     }
   }
 }
 
-@riverpod
+Duration? _qrCodeRetry(int retryCount, Object error) {
+  if (error is TermsNotAgreed) return null;
+  return ProviderContainer.defaultRetry(retryCount, error);
+}
+
+@Riverpod(retry: _qrCodeRetry)
 Future<String> qrCode(Ref ref) async {
   return await QRCodeRepository.getInstance().getQRCode();
 }
@@ -61,7 +68,10 @@ class QRDialog extends HookConsumerWidget {
     switch (qrCode) {
       case AsyncData(:final value):
         body = QrImageView(
-            data: value, size: 200.0, backgroundColor: Colors.white);
+          data: value,
+          size: 200.0,
+          backgroundColor: Colors.white,
+        );
       case AsyncLoading():
         body = Text(S.of(context).loading_qr_code);
       case AsyncError(:final error, :final stackTrace):
@@ -69,8 +79,12 @@ class QRDialog extends HookConsumerWidget {
           termsNotAgreed = true;
           body = Text(S.of(context).qr_code_terms_not_agreed);
         } else {
-          body = ErrorPageWidget.buildWidget(context, error,
-              stackTrace: stackTrace, onTap: () => ref.refresh(qrCodeProvider));
+          body = ErrorPageWidget.buildWidget(
+            context,
+            error,
+            stackTrace: stackTrace,
+            onTap: () => ref.refresh(qrCodeProvider),
+          );
         }
       case _:
         body = const SizedBox.shrink();
@@ -79,17 +93,20 @@ class QRDialog extends HookConsumerWidget {
     return PlatformAlertDialog(
       title: Text(S.of(context).fudan_qr_code),
       content: SizedBox(
-          width: double.maxFinite, height: 200.0, child: Center(child: body)),
+        width: double.maxFinite,
+        height: 200.0,
+        child: Center(child: body),
+      ),
       actions: <Widget>[
         TextButton(
-            child: PlatformText(S.of(context).i_see),
-            onPressed: () async {
-              Navigator.pop(context);
-              if (termsNotAgreed) {
-                BrowserUtil.openUrl(
-                    QRCodeRepository.QR_URL, context, null, true);
-              }
-            }),
+          child: PlatformText(S.of(context).i_see),
+          onPressed: () async {
+            Navigator.pop(context);
+            if (termsNotAgreed) {
+              BrowserUtil.openUrl(QRCodeRepository.QR_URL, context, null, true);
+            }
+          },
+        ),
       ],
     );
   }

--- a/lib/widget/dialogs/qr_code_dialog.dart
+++ b/lib/widget/dialogs/qr_code_dialog.dart
@@ -25,7 +25,6 @@ import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:riverpod/riverpod.dart'; // 为 ProviderContainer.defaultRetry
 
 part 'qr_code_dialog.g.dart';
 


### PR DESCRIPTION
Bug 表现：未同意条款时一直加载复活码，不显示报错页面。
<img width="1440" height="3200" alt="806c1ae698deccc544c06b4582092780" src="https://github.com/user-attachments/assets/040cf3d0-dd08-4936-9b33-395db1937d45" />

原因分析（藏得真深不用 AI 我还真寻思不出来……）：`qrCodeProvider` 作为 `autoDispose` 的 `FutureProvider`，其异常没有被作为 `fatal error` 正确向上传播。

修复：应用了自定义的 `retry` 方法阻止了 `TermsNotAgreed Exception` 下的重试，但是其他 Exception 应该还是会出现无限重试的情况。个人认为无伤大雅就没改。

整改情况：
<img width="1584" height="892" alt="image" src="https://github.com/user-attachments/assets/cda541b1-61b7-4d16-bbb5-fdad54d18d1c" />
