### PR TITLE
fix(ai-summary): use empty lists when the backend responds with nulls

### DIFF
--- a/lib/model/forum/ai_summary.dart
+++ b/lib/model/forum/ai_summary.dart
@@ -47,8 +47,11 @@ class AiSummaryResponse {
 class AiSummaryData {
   final int hole_id;
   final String summary;
+  @JsonKey(defaultValue: [])
   final List<AiSummaryBranch> branches;
+  @JsonKey(defaultValue: [])
   final List<AiSummaryInteraction> interactions;
+  @JsonKey(defaultValue: [])
   final List<String> keywords;
   final String generated_at;
   final String trace_id;


### PR DESCRIPTION
The backend can responds with:
```
{
  code: 1001,
  message: "processing",
  data: {
    hole_id: 0,
    trace_id: "",
    summary: "",
    branches: null,
    interactions: null,
    keywords: null,
    generated_at: "",
  },
}
```

Therefore default values are needed for backend-nullable fields. Or as another fix, the backend can return data as `null` or `{}`.